### PR TITLE
Make Rectangle's point fields public.

### DIFF
--- a/.changes/public.md
+++ b/.changes/public.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": "minor"
+---
+
+Make Rectangle's point fields public.

--- a/.changes/public.md
+++ b/.changes/public.md
@@ -1,5 +1,5 @@
 ---
-"tray-icon": "minor"
+"tray-icon": "patch"
 ---
 
 Make Rectangle's point fields public.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,10 +375,10 @@ pub enum ClickEvent {
 /// Describes a rectangle including position (x - y axis) and size.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Rectangle {
-    left: f64,
-    right: f64,
-    top: f64,
-    bottom: f64,
+    pub left: f64,
+    pub right: f64,
+    pub top: f64,
+    pub bottom: f64,
 }
 
 /// A reciever that could be used to listen to tray events.


### PR DESCRIPTION
I'm working on an app that needs to create a window above or below the tray icon. Couldn't find another way to consistently place the window without making these public.