### PR TITLE
chore: update debian dependencies in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ tray-icon lets you create tray icons for desktop applications.
 
 ## Dependencies (Linux Only)
 
-On Linux, `gtk` and `libappindicator` or `libayatnat-appindicator` are used to create the tray icon, so make sure to install them on your system.
+On Linux, `gtk`, `libxdo` is used to make the predfined `Copy`, `Cut`, `Paste` and `SelectAll` menu items work and `libappindicator` or `libayatnat-appindicator` are used to create the tray icon, so make sure to install them on your system.
 
 #### Arch Linux / Manjaro:
 
 ```sh
-pacman -S gtk3 libappindicator-gtk3 #or libayatana-appindicator
+pacman -S gtk3 xdotool libappindicator-gtk3 #or libayatana-appindicator
 ```
 
 #### Debian / Ubuntu:
@@ -32,8 +32,6 @@ pacman -S gtk3 libappindicator-gtk3 #or libayatana-appindicator
 ```sh
 sudo apt install libgtk-3-dev libxdo-dev libappindicator3-dev #or libayatana-appindicator3-dev
 ```
-
-if you use `tray_icon::muda` module, make sure to checkout https://github.com/tauri-apps/muda#dependencies
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pacman -S gtk3 libappindicator-gtk3 #or libayatana-appindicator
 #### Debian / Ubuntu:
 
 ```sh
-sudo apt install libgtk-3-dev libappindicator3-dev #or libayatana-appindicator3-dev
+sudo apt install libgtk-3-dev libxdo-dev libappindicator3-dev #or libayatana-appindicator3-dev
 ```
 
 if you use `tray_icon::muda` module, make sure to checkout https://github.com/tauri-apps/muda#dependencies


### PR DESCRIPTION
libxdo-dev was missing for me on mint 21, compiled fine after adding it. Thought I'd include it in the readme :)

Error without this dependency: `/usr/bin/ld: cannot find -lxdo: No such file or directory`