### PR TITLE
fix: add a counter to the temporary icon path to avoid gtk caching

### DIFF
--- a/.changes/patch-fix-cached-icons.md
+++ b/.changes/patch-fix-cached-icons.md
@@ -2,4 +2,4 @@
 "tray-icon": patch
 ---
 
-Fixes the issue that gtk caches the icon if you use **set_icon** repeatedly
+On Linux, fix the issue that gtk caches the icon if you use `TrayIcon::set_icon` repeatedly.

--- a/.changes/patch-fix-cached-icons.md
+++ b/.changes/patch-fix-cached-icons.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+Fixes the issue that gtk caches the icon if you use **set_icon** repeatedly

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -54,7 +54,8 @@ impl TrayIcon {
 
         self.counter += 1;
 
-        let (parent_path, icon_path) = temp_icon_path(self.temp_dir_path.as_ref(), self.id, self.counter)?;
+        let (parent_path, icon_path) =
+            temp_icon_path(self.temp_dir_path.as_ref(), self.id, self.counter)?;
 
         if let Some(icon) = icon {
             icon.inner.write_to_png(&icon_path);
@@ -110,7 +111,11 @@ impl Drop for TrayIcon {
 /// 1. If `temp_icon_dir` is `Some` use that.
 /// 2. `$XDG_RUNTIME_DIR/tray-icon`
 /// 3. `/tmp/tray-icon`
-fn temp_icon_path(temp_icon_dir: Option<&PathBuf>, id: u32, counter: u32) -> std::io::Result<(PathBuf, PathBuf)> {
+fn temp_icon_path(
+    temp_icon_dir: Option<&PathBuf>,
+    id: u32,
+    counter: u32,
+) -> std::io::Result<(PathBuf, PathBuf)> {
     let parent_path = match temp_icon_dir.as_ref() {
         Some(path) => path.to_path_buf(),
         None => dirs_next::runtime_dir()

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -16,6 +16,7 @@ pub struct TrayIcon {
     indicator: AppIndicator,
     temp_dir_path: Option<PathBuf>,
     path: PathBuf,
+    counter: u32,
 }
 
 impl TrayIcon {
@@ -23,7 +24,7 @@ impl TrayIcon {
         let mut indicator = AppIndicator::new("tray-icon tray app", "");
         indicator.set_status(AppIndicatorStatus::Active);
 
-        let (parent_path, icon_path) = temp_icon_path(attrs.temp_dir_path.as_ref(), id)?;
+        let (parent_path, icon_path) = temp_icon_path(attrs.temp_dir_path.as_ref(), id, 0)?;
 
         if let Some(icon) = attrs.icon {
             icon.inner.write_to_png(&icon_path);
@@ -45,12 +46,15 @@ impl TrayIcon {
             indicator,
             path: icon_path,
             temp_dir_path: attrs.temp_dir_path,
+            counter: 0,
         })
     }
     pub fn set_icon(&mut self, icon: Option<Icon>) -> crate::Result<()> {
         let _ = std::fs::remove_file(&self.path);
 
-        let (parent_path, icon_path) = temp_icon_path(self.temp_dir_path.as_ref(), self.id)?;
+        self.counter += 1;
+
+        let (parent_path, icon_path) = temp_icon_path(self.temp_dir_path.as_ref(), self.id, self.counter)?;
 
         if let Some(icon) = icon {
             icon.inner.write_to_png(&icon_path);
@@ -106,7 +110,7 @@ impl Drop for TrayIcon {
 /// 1. If `temp_icon_dir` is `Some` use that.
 /// 2. `$XDG_RUNTIME_DIR/tray-icon`
 /// 3. `/tmp/tray-icon`
-fn temp_icon_path(temp_icon_dir: Option<&PathBuf>, id: u32) -> std::io::Result<(PathBuf, PathBuf)> {
+fn temp_icon_path(temp_icon_dir: Option<&PathBuf>, id: u32, counter: u32) -> std::io::Result<(PathBuf, PathBuf)> {
     let parent_path = match temp_icon_dir.as_ref() {
         Some(path) => path.to_path_buf(),
         None => dirs_next::runtime_dir()
@@ -115,7 +119,7 @@ fn temp_icon_path(temp_icon_dir: Option<&PathBuf>, id: u32) -> std::io::Result<(
     };
 
     std::fs::create_dir_all(&parent_path)?;
-    let icon_path = parent_path.join(format!("tray-icon-{}.png", id));
+    let icon_path = parent_path.join(format!("tray-icon-{}-{}.png", id, counter));
     Ok((parent_path, icon_path))
 }
 
@@ -124,10 +128,10 @@ fn temp_icon_path_preference_order() {
     let runtime_dir = option_env!("XDG_RUNTIME_DIR");
     let override_dir = PathBuf::from("/tmp/tao-tests");
 
-    let (dir1, _file1) = temp_icon_path(Some(&override_dir), 00).unwrap();
-    let (dir2, _file1) = temp_icon_path(None, 00).unwrap();
+    let (dir1, _file1) = temp_icon_path(Some(&override_dir), 00, 00).unwrap();
+    let (dir2, _file1) = temp_icon_path(None, 00, 00).unwrap();
     std::env::remove_var("XDG_RUNTIME_DIR");
-    let (dir3, _file2) = temp_icon_path(None, 00).unwrap();
+    let (dir3, _file2) = temp_icon_path(None, 00, 00).unwrap();
 
     assert_eq!(dir1, override_dir);
     if let Some(runtime_dir) = runtime_dir {


### PR DESCRIPTION
At least on my desktop, the temp-icon **tray-icon-1.png** is cached, so that subsequent updates via the set_icon method do not have an effect.

This PR adds a counter to the TrayIcon struct, which is appended to the temp-filename **tray-icon-<ID>-<Counter>.png** and incremented everytime the set_icon method is called.