### PR TITLE
fix(linux): Use after free in TrayIconBuilder::with_menu (#89)

### DIFF
--- a/.changes/linux-tray-menu.md
+++ b/.changes/linux-tray-menu.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+On Linux, fix tray menu failing to show.

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use icon::PlatformIcon;
 
 use crate::{TrayIconAttributes, TrayIconId, COUNTER};
 use libappindicator::{AppIndicator, AppIndicatorStatus};
+use muda::ContextMenu;
 
 pub struct TrayIcon {
     id: u32,
@@ -17,6 +18,7 @@ pub struct TrayIcon {
     temp_dir_path: Option<PathBuf>,
     path: PathBuf,
     counter: u32,
+    menu: Option<Box<dyn ContextMenu>>,
 }
 
 impl TrayIcon {
@@ -34,9 +36,10 @@ impl TrayIcon {
         indicator.set_icon_theme_path(&parent_path.to_string_lossy());
         indicator.set_icon_full(&icon_path.to_string_lossy(), "icon");
 
-        if let Some(menu) = attrs.menu {
+        let menu = attrs.menu.map(|menu| {
             indicator.set_menu(&mut menu.gtk_context_menu());
-        }
+            menu
+        });
 
         if let Some(title) = attrs.title {
             indicator.set_label(title.as_str(), "");
@@ -48,6 +51,7 @@ impl TrayIcon {
             path: icon_path,
             temp_dir_path: attrs.temp_dir_path,
             counter: 0,
+            menu
         })
     }
     pub fn set_icon(&mut self, icon: Option<Icon>) -> crate::Result<()> {
@@ -74,6 +78,7 @@ impl TrayIcon {
     pub fn set_menu(&mut self, menu: Option<Box<dyn crate::menu::ContextMenu>>) {
         if let Some(menu) = menu {
             self.indicator.set_menu(&mut menu.gtk_context_menu());
+            self.menu = Some(menu);
         }
     }
 

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -10,7 +10,6 @@ pub(crate) use icon::PlatformIcon;
 
 use crate::{TrayIconAttributes, TrayIconId, COUNTER};
 use libappindicator::{AppIndicator, AppIndicatorStatus};
-use muda::ContextMenu;
 
 pub struct TrayIcon {
     id: u32,
@@ -18,7 +17,7 @@ pub struct TrayIcon {
     temp_dir_path: Option<PathBuf>,
     path: PathBuf,
     counter: u32,
-    menu: Option<Box<dyn ContextMenu>>,
+    menu: Option<Box<dyn muda::ContextMenu>>,
 }
 
 impl TrayIcon {
@@ -36,10 +35,9 @@ impl TrayIcon {
         indicator.set_icon_theme_path(&parent_path.to_string_lossy());
         indicator.set_icon_full(&icon_path.to_string_lossy(), "icon");
 
-        let menu = attrs.menu.map(|menu| {
+        if let Some(menu) = &attrs.menu {
             indicator.set_menu(&mut menu.gtk_context_menu());
-            menu
-        });
+        }
 
         if let Some(title) = attrs.title {
             indicator.set_label(title.as_str(), "");
@@ -51,7 +49,7 @@ impl TrayIcon {
             path: icon_path,
             temp_dir_path: attrs.temp_dir_path,
             counter: 0,
-            menu
+            menu: attrs.menu,
         })
     }
     pub fn set_icon(&mut self, icon: Option<Icon>) -> crate::Result<()> {
@@ -76,10 +74,10 @@ impl TrayIcon {
     }
 
     pub fn set_menu(&mut self, menu: Option<Box<dyn crate::menu::ContextMenu>>) {
-        if let Some(menu) = menu {
+        if let Some(menu) = &menu {
             self.indicator.set_menu(&mut menu.gtk_context_menu());
-            self.menu = Some(menu);
         }
+        self.menu = menu;
     }
 
     pub fn set_tooltip<S: AsRef<str>>(&mut self, _tooltip: Option<S>) -> crate::Result<()> {


### PR DESCRIPTION
Fixes #89.

When adding a menu to a tray icon this crate internally creates a GTK menu (wrapped in `muda::ContextMenu`) which is unfortunately dropped by Rust. This results in a segfault / use after free in libappindicator / GTK when clicking the tray icon.

I don't know if this is the right way to fix this but it works. IIRC tauri has something like app::manage which takes care of the references.