### PR TITLE
feat: expose `Icon::from_handle`

### DIFF
--- a/.changes/icon_from_handle.md
+++ b/.changes/icon_from_handle.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": "patch"
+---
+
+Add `Icon::from_hicon`

--- a/.changes/icon_from_handle.md
+++ b/.changes/icon_from_handle.md
@@ -2,4 +2,4 @@
 "tray-icon": "patch"
 ---
 
-Add `Icon::from_hicon`
+On Windows, add `Icon::from_handle`

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -164,9 +164,9 @@ impl Icon {
         Ok(Icon { inner: win_icon })
     }
 
-    /// Create an icon from a hicon
+    /// Create an icon from an HICON
     #[cfg(windows)]
-    pub fn from_handle(handle: windows_sys::Win32::UI::WindowsAndMessaging::HICON) -> Self {
+    pub fn from_handle(handle: isize) -> Self {
         let win_icon = PlatformIcon::from_handle(handle);
         Icon { inner: win_icon }
     }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -163,4 +163,11 @@ impl Icon {
         let win_icon = PlatformIcon::from_resource(ordinal, size)?;
         Ok(Icon { inner: win_icon })
     }
+
+    /// Create an icon from a hicon
+    #[cfg(windows)]
+    pub fn from_handle(handle: windows_sys::Win32::UI::WindowsAndMessaging::HICON) -> Self {
+        let win_icon = PlatformIcon::from_handle(handle);
+        Icon { inner: win_icon }
+    }
 }

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -76,7 +76,7 @@ impl WinIcon {
         rgba_icon.into_windows_icon()
     }
 
-    fn from_handle(handle: HICON) -> Self {
+    pub(crate) fn from_handle(handle: HICON) -> Self {
         Self {
             inner: Arc::new(RaiiIcon { handle }),
         }


### PR DESCRIPTION
I'm writing a windows app in which I already have a `HICON`, but I couldn't find a good way to massage it to be used with tray-icon... Maybe the proper way is to use some sort of `Into<Icon>` trait, but this at least unblocks me easily