### PR TITLE
fix: fix `set_visible` method incorrect behavior on Linux

### DIFF
--- a/.changes/linux-set-visible.md
+++ b/.changes/linux-set-visible.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+On Linux, fix `TrayIcon::set_visible` incorrect inverted behavior.

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -91,9 +91,9 @@ impl TrayIcon {
 
     pub fn set_visible(&mut self, visible: bool) -> crate::Result<()> {
         if visible {
-            self.indicator.set_status(AppIndicatorStatus::Passive);
-        } else {
             self.indicator.set_status(AppIndicatorStatus::Active);
+        } else {
+            self.indicator.set_status(AppIndicatorStatus::Passive);
         }
 
         Ok(())


### PR DESCRIPTION
Hi,

This should be the other way around. 

https://martchus.no-ip.biz/doc/gtk/libappindicator/libappindicator-app-indicator.html

APP_INDICATOR_STATUS_PASSIVE  The indicator should not be shown to the user.
APP_INDICATOR_STATUS_ACTIVE The indicator should be shown in it's default state.

Not sure what are the contributing guidelines. Hope this is fine. 