### PR TITLE
fix: reset image on template change

### DIFF
--- a/.changes/macos-template.md
+++ b/.changes/macos-template.md
@@ -1,0 +1,5 @@
+---
+'tray-icon': patch
+---
+
+On macOS, reset the tray icon when using `setIconAsTemplate` to avoid artifacts.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -203,6 +203,7 @@ impl TrayIcon {
                 let button = ns_status_item.button();
                 let nsimage: id = msg_send![button, image];
                 let _: () = msg_send![nsimage, setTemplate: is_template as i8];
+                button.setImage_(nsimage);
             }
         }
         self.attrs.icon_is_template = is_template;


### PR DESCRIPTION
Hi,

I have noticed that on macOS when alternating between colored tray icon and template image, sometimes the tray icon doesn't reflect the "template" setting. I have described that in more detail in https://github.com/tauri-apps/tauri/issues/9332

This PR fixes this by tossing the same NSImage at tray after updating the `isTemplate` setting which forces the icon to repaint.

closes tauri-apps/tauri#9332