### PR TITLE
fix(macOS): return the correct tray icon size

### DIFF
--- a/.changes/macos-rect-size.md
+++ b/.changes/macos-rect-size.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+Fix incorrect icon size reported in events on macOS

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -352,7 +352,7 @@ fn make_tray_target_class() -> *const Class {
             let scale_factor = NSWindow::backingScaleFactor(window);
 
             let icon_rect = Rect {
-                size: crate::dpi::LogicalSize::new(frame.origin.x, frame.origin.y)
+                size: crate::dpi::LogicalSize::new(frame.size.width, frame.size.height)
                     .to_physical(scale_factor),
                 position: crate::dpi::LogicalPosition::new(
                     frame.origin.x,


### PR DESCRIPTION
I assume by mistake, the size of tray icon on macOS is filled with frame position instead of frame size. This PR fixes this.

Fixes #133