### PR TITLE
chore: Reduce CPU load in examples by polling each 16 ms 

### DIFF
--- a/examples/tao.rs
+++ b/examples/tao.rs
@@ -39,7 +39,7 @@ fn main() {
     event_loop.run(move |event, _, control_flow| {
         // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
         // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
-        // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
+        // Alternatively, you can set ControlFlow::Wait or use TrayIconEvent::set_event_handler,
         // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
         *control_flow = ControlFlow::WaitUntil(
             std::time::Instant::now() + std::time::Duration::from_millis(16),

--- a/examples/tao.rs
+++ b/examples/tao.rs
@@ -37,7 +37,13 @@ fn main() {
     let tray_channel = TrayIconEvent::receiver();
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Poll;
+        // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
+        // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
+        // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
+        // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
+        *control_flow = ControlFlow::WaitUntil(
+            std::time::Instant::now() + std::time::Duration::from_millis(16),
+        );
 
         if let tao::event::Event::NewEvents(tao::event::StartCause::Init) = event {
             let icon = load_icon(std::path::Path::new(path));
@@ -75,12 +81,6 @@ fn main() {
         if let Ok(event) = tray_channel.try_recv() {
             println!("{event:?}");
         }
-
-        // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
-        // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
-        // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
-        // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
-        std::thread::sleep(core::time::Duration::from_millis(16));
     })
 }
 

--- a/examples/tao.rs
+++ b/examples/tao.rs
@@ -76,12 +76,11 @@ fn main() {
             println!("{event:?}");
         }
 
-    // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
-    // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
-    // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
-    // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
-    std::thread::sleep(core::time::Duration::from_millis(16));
-
+        // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
+        // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
+        // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
+        // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
+        std::thread::sleep(core::time::Duration::from_millis(16));
     })
 }
 

--- a/examples/tao.rs
+++ b/examples/tao.rs
@@ -75,6 +75,13 @@ fn main() {
         if let Ok(event) = tray_channel.try_recv() {
             println!("{event:?}");
         }
+
+    // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
+    // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
+    // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
+    // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
+    std::thread::sleep(core::time::Duration::from_millis(16));
+
     })
 }
 

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -48,7 +48,7 @@ fn main() {
         event_loop.set_control_flow(ControlFlow::WaitUntil(
             std::time::Instant::now() + std::time::Duration::from_millis(16),
         ));
-        
+
         #[cfg(not(target_os = "linux"))]
         if let winit::event::Event::NewEvents(winit::event::StartCause::Init) = event {
             let icon = load_icon(std::path::Path::new(path));

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -43,7 +43,7 @@ fn main() {
     event_loop.run(move |event, event_loop| {
         // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
         // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
-        // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
+        // Alternatively, you can set ControlFlow::Wait or use TrayIconEvent::set_event_handler,
         // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
         event_loop.set_control_flow(ControlFlow::WaitUntil(
             std::time::Instant::now() + std::time::Duration::from_millis(16),

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -73,12 +73,11 @@ fn main() {
             println!("{event:?}");
         }
 
-    // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
-    // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
-    // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
-    // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
-    std::thread::sleep(core::time::Duration::from_millis(16));
-
+        // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
+        // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
+        // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
+        // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
+        std::thread::sleep(core::time::Duration::from_millis(16));
     });
 }
 

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -72,6 +72,13 @@ fn main() {
         if let Ok(event) = tray_channel.try_recv() {
             println!("{event:?}");
         }
+
+    // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
+    // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
+    // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
+    // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
+    std::thread::sleep(core::time::Duration::from_millis(16));
+
     });
 }
 


### PR DESCRIPTION
This tiny PR adds a small delay of 16 ms (60fps) to event_loop to reduce CPU load.

Currently the **Tao** and **Winit** examples use 100% CPU load on 1 thread because `Controlflow:Poll` fires on every CPU cycle. This can be reduced to be less than 1% by introducing small sleep time on the event loop thread.

I think 16 ms (60fps) delay is acceptable as for example windows default timer has a resolution of 15.6 ms. Of course users can comment the `std::thread::sleep` line to undo the change.

This affects only the **Tao** and **Winit** examples, **Egui** seems to already handle the update loop so that the CPU load is not high.

There is also a reference to issue https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065 which explains how users can change the structure of the event loop with [MenuEvent::set_event_handler](https://docs.rs/muda/latest/muda/struct.MenuEvent.html#method.set_event_handler) and [TrayIconEvent::set_event_handler](https://docs.rs/tray-icon/latest/tray_icon/struct.TrayIconEvent.html#method.set_event_handler) to be more like Tauri.

```rust
    // We add delay of 16 ms (60fps) to event_loop to reduce cpu load.
    // This can be removed to allow ControlFlow::Poll to poll on each cpu cycle
    // Alternatively, you can set ControlFlow::Wait or use MenuEvent::set_event_handler,
    // see https://github.com/tauri-apps/tray-icon/issues/83#issuecomment-1697773065
    std::thread::sleep(core::time::Duration::from_millis(16));
```