### PR TITLE
fix(windows): tray icon gets blurry after changing dpi

### DIFF
--- a/.changes/blurry-after-dpi-change-windows.md
+++ b/.changes/blurry-after-dpi-change-windows.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+Fix tray icon gets blurry after changing dpi on Windows

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -10,7 +10,7 @@ use once_cell::sync::Lazy;
 use windows_sys::{
     s,
     Win32::{
-        Foundation::{HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
+        Foundation::{FALSE, HWND, LPARAM, LRESULT, POINT, RECT, TRUE, WPARAM},
         UI::{
             Shell::{
                 DefSubclassProc, SetWindowSubclass, Shell_NotifyIconGetRect, Shell_NotifyIconW,
@@ -309,6 +309,7 @@ unsafe extern "system" fn tray_subclass_proc(
             subclass_input.tooltip = *tooltip;
         }
         _ if msg == *S_U_TASKBAR_RESTART => {
+            remove_tray_icon(subclass_input.hwnd, subclass_input.internal_id);
             register_tray_icon(
                 subclass_input.hwnd,
                 subclass_input.internal_id,
@@ -432,7 +433,7 @@ unsafe fn register_tray_icon(
         ..std::mem::zeroed()
     };
 
-    Shell_NotifyIconW(NIM_ADD, &mut nid as _) == 1
+    Shell_NotifyIconW(NIM_ADD, &mut nid as _) == TRUE
 }
 
 unsafe fn remove_tray_icon(hwnd: HWND, id: u32) {
@@ -443,7 +444,7 @@ unsafe fn remove_tray_icon(hwnd: HWND, id: u32) {
         ..std::mem::zeroed()
     };
 
-    if Shell_NotifyIconW(NIM_DELETE, &mut nid as _) == 0 {
+    if Shell_NotifyIconW(NIM_DELETE, &mut nid as _) == FALSE {
         eprintln!("Error removing system tray icon");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/tauri-apps/tauri/issues/9335

Re-add tray icon on `TaskbarCreated` message

This is what Electron does

> https://github.com/electron/electron/blob/b41da150caa363d06f522427c87bd989464c9edd/shell/browser/ui/win/notify_icon_host.cc#L244-L251
> https://github.com/electron/electron/blob/b41da150caa363d06f522427c87bd989464c9edd/shell/browser/ui/win/notify_icon.cc#L114-L131

I don't quite understand why the Power Toys' implementation doesn't use the `NIM_DELETE` while still works

> https://github.com/microsoft/PowerToys/blob/28ba2bd301f47250e53876d21d240ba5434bb7af/src/runner/tray_icon.cpp#L253-L257

The document didn't mention deleting the existing icon as well

> When the taskbar is created, it registers a message with the TaskbarCreated string and then broadcasts this message to all top-level windows. When your taskbar application receives this message, it should assume that any taskbar icons it added have been removed and add them again.
> https://learn.microsoft.com/en-us/windows/win32/shell/taskbar#taskbar-creation-notification