### PR TITLE
feat: add `TrayIcon::rect()`

### DIFF
--- a/.changes/tray-icon-rect.md
+++ b/.changes/tray-icon-rect.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": "patch"
+---
+
+Add `TrayIcon::rect` method to retrieve the tray icon rectangle on Windows and macOS.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,17 +395,13 @@ impl TrayIcon {
         let _ = enable;
     }
 
-    /// Get tray icon frame when available, otherwise `None`. **macOS only**.
-    pub fn get_frame_rect(&self) -> Option<Rect> {
-        #[cfg(target_os = "macos")]
-        {
-            self.tray.borrow().get_frame_rect()
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        {
-            None
-        }
+    /// Get tray icon rect.
+    ///
+    /// ## Platform-specific:
+    ///
+    /// - **Linux**: Unsupported.
+    pub fn rect(&self) -> Option<Rect> {
+        self.tray.borrow().rect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,6 +394,19 @@ impl TrayIcon {
         #[cfg(not(target_os = "macos"))]
         let _ = enable;
     }
+
+    /// Get tray icon frame when available, otherwise `None`. **macOS only**.
+    pub fn get_frame_rect(&self) -> Option<Rect> {
+        #[cfg(target_os = "macos")]
+        {
+            self.tray.borrow().get_frame_rect()
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            None
+        }
+    }
 }
 
 /// Describes a tray event emitted when a tray icon is clicked

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -103,7 +103,7 @@ impl TrayIcon {
         self.temp_dir_path = path.map(|p| p.as_ref().to_path_buf());
     }
 
-    pub fn rect(&self) -> Option<Rect> {
+    pub fn rect(&self) -> Option<crate::Rect> {
         None
     }
 }

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -102,6 +102,10 @@ impl TrayIcon {
     pub fn set_temp_dir_path<P: AsRef<Path>>(&mut self, path: Option<P>) {
         self.temp_dir_path = path.map(|p| p.as_ref().to_path_buf());
     }
+
+    pub fn rect(&self) -> Option<Rect> {
+        None
+    }
 }
 
 impl Drop for TrayIcon {

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -221,7 +221,7 @@ impl TrayIcon {
         self.attrs.menu_on_left_click = enable;
     }
 
-    pub fn get_frame_rect(&self) -> Option<Rect> {
+    pub fn rect(&self) -> Option<Rect> {
         let ns_status_item = self.ns_status_item?;
         unsafe {
             let button = ns_status_item.button();

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -6,7 +6,10 @@ mod icon;
 use std::sync::Once;
 
 use cocoa::{
-    appkit::{NSButton, NSImage, NSStatusBar, NSStatusItem, NSVariableStatusItemLength, NSWindow},
+    appkit::{
+        NSButton, NSEvent, NSImage, NSStatusBar, NSStatusItem, NSVariableStatusItemLength, NSView,
+        NSWindow,
+    },
     base::{id, nil},
     foundation::{NSData, NSInteger, NSPoint, NSRect, NSSize, NSString},
 };
@@ -216,6 +219,33 @@ impl TrayIcon {
             }
         }
         self.attrs.menu_on_left_click = enable;
+    }
+
+    pub fn get_frame_rect(&self) -> Option<Rect> {
+        let ns_status_item = self.ns_status_item?;
+        unsafe {
+            let button = ns_status_item.button();
+            let window: id = button.window();
+            if window.is_null() {
+                None
+            } else {
+                let rect_in_window: NSRect =
+                    msg_send![button, convertRect:button.bounds() toView:nil];
+                let screen_rect = window.convertRectToScreen_(rect_in_window);
+
+                Some(Rect {
+                    position: crate::dpi::PhysicalPosition::new(
+                        screen_rect.origin.x,
+                        screen_rect.origin.y,
+                    ),
+                    size: crate::dpi::PhysicalSize::new(
+                        screen_rect.size.width,
+                        screen_rect.size.height,
+                    )
+                    .cast(),
+                })
+            }
+        }
     }
 }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -7,8 +7,7 @@ use std::sync::Once;
 
 use cocoa::{
     appkit::{
-        NSButton, NSEvent, NSImage, NSStatusBar, NSStatusItem, NSVariableStatusItemLength, NSView,
-        NSWindow,
+        NSButton, NSEvent, NSImage, NSStatusBar, NSStatusItem, NSVariableStatusItemLength, NSWindow,
     },
     base::{id, nil},
     foundation::{NSData, NSInteger, NSPoint, NSRect, NSSize, NSString},
@@ -229,20 +228,17 @@ impl TrayIcon {
             if window.is_null() {
                 None
             } else {
-                let rect_in_window: NSRect =
-                    msg_send![button, convertRect:button.bounds() toView:nil];
-                let screen_rect = window.convertRectToScreen_(rect_in_window);
+                let frame = NSWindow::frame(window);
+                let scale_factor = NSWindow::backingScaleFactor(window);
 
                 Some(Rect {
-                    position: crate::dpi::PhysicalPosition::new(
-                        screen_rect.origin.x,
-                        screen_rect.origin.y,
-                    ),
-                    size: crate::dpi::PhysicalSize::new(
-                        screen_rect.size.width,
-                        screen_rect.size.height,
+                    size: crate::dpi::LogicalSize::new(frame.size.width, frame.size.height)
+                        .to_physical(scale_factor),
+                    position: crate::dpi::LogicalPosition::new(
+                        frame.origin.x,
+                        flip_window_screen_coordinates(frame.origin.y),
                     )
-                    .cast(),
+                    .to_physical(scale_factor),
                 })
             }
         }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -228,18 +228,7 @@ impl TrayIcon {
             if window.is_null() {
                 None
             } else {
-                let frame = NSWindow::frame(window);
-                let scale_factor = NSWindow::backingScaleFactor(window);
-
-                Some(Rect {
-                    size: crate::dpi::LogicalSize::new(frame.size.width, frame.size.height)
-                        .to_physical(scale_factor),
-                    position: crate::dpi::LogicalPosition::new(
-                        frame.origin.x,
-                        flip_window_screen_coordinates(frame.origin.y),
-                    )
-                    .to_physical(scale_factor),
-                })
+                Some(get_tray_rect(window))
             }
         }
     }
@@ -377,18 +366,7 @@ fn make_tray_target_class() -> *const Class {
 
             // icon position & size
             let window: id = msg_send![event, window];
-            let frame = NSWindow::frame(window);
-            let scale_factor = NSWindow::backingScaleFactor(window);
-
-            let icon_rect = Rect {
-                size: crate::dpi::LogicalSize::new(frame.size.width, frame.size.height)
-                    .to_physical(scale_factor),
-                position: crate::dpi::LogicalPosition::new(
-                    frame.origin.x,
-                    flip_window_screen_coordinates(frame.origin.y),
-                )
-                .to_physical(scale_factor),
-            };
+            let icon_rect = get_tray_rect(window);
 
             // cursor position
             let mouse_location: NSPoint = msg_send![class!(NSEvent), mouseLocation];
@@ -433,6 +411,21 @@ fn make_tray_target_class() -> *const Class {
     });
 
     unsafe { TRAY_CLASS }
+}
+
+fn get_tray_rect(window: id) -> Rect {
+    let frame = unsafe { NSWindow::frame(window) };
+    let scale_factor = unsafe { NSWindow::backingScaleFactor(window) };
+
+    Rect {
+        size: crate::dpi::LogicalSize::new(frame.size.width, frame.size.height)
+            .to_physical(scale_factor),
+        position: crate::dpi::LogicalPosition::new(
+            frame.origin.x,
+            flip_window_screen_coordinates(frame.origin.y),
+        )
+        .to_physical(scale_factor),
+    }
 }
 
 /// Core graphics screen coordinates are relative to the top-left corner of

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -251,33 +251,9 @@ impl TrayIcon {
     }
 
     pub fn rect(&self) -> Option<Rect> {
-        let nid = NOTIFYICONIDENTIFIER {
-            hWnd: self.hwnd,
-            cbSize: std::mem::size_of::<NOTIFYICONIDENTIFIER>() as _,
-            uID: self.internal_id,
-            ..unsafe { std::mem::zeroed() }
-        };
-
-        let mut icon_rect = RECT {
-            left: 0,
-            bottom: 0,
-            right: 0,
-            top: 0,
-        };
-        unsafe { Shell_NotifyIconGetRect(&nid, &mut icon_rect) };
-
         let dpi = unsafe { util::hwnd_dpi(self.hwnd) };
         let scale_factor = util::dpi_to_scale_factor(dpi);
-
-        Some(Rect {
-            position: crate::dpi::LogicalPosition::new(icon_rect.left, icon_rect.top)
-                .to_physical(scale_factor),
-            size: crate::dpi::LogicalSize::new(
-                icon_rect.right.saturating_sub(icon_rect.left),
-                icon_rect.bottom.saturating_sub(icon_rect.top),
-            )
-            .to_physical(scale_factor),
-        })
+        Some(get_tray_rect(self.internal_id, self.hwnd, scale_factor))
     }
 }
 
@@ -355,20 +331,6 @@ unsafe extern "system" fn tray_subclass_proc(
                 WM_LBUTTONUP | WM_RBUTTONUP | WM_LBUTTONDBLCLK
             ) =>
         {
-            let nid = NOTIFYICONIDENTIFIER {
-                hWnd: hwnd,
-                cbSize: std::mem::size_of::<NOTIFYICONIDENTIFIER>() as _,
-                uID: subclass_input.internal_id,
-                ..std::mem::zeroed()
-            };
-            let mut icon_rect = RECT {
-                left: 0,
-                bottom: 0,
-                right: 0,
-                top: 0,
-            };
-            Shell_NotifyIconGetRect(&nid, &mut icon_rect);
-
             let mut cursor = POINT { x: 0, y: 0 };
             GetCursorPos(&mut cursor as _);
 
@@ -388,15 +350,7 @@ unsafe extern "system" fn tray_subclass_proc(
             TrayIconEvent::send(crate::TrayIconEvent {
                 id: subclass_input.id.clone(),
                 position: crate::dpi::LogicalPosition::new(x, y).to_physical(scale_factor),
-                icon_rect: Rect {
-                    position: crate::dpi::LogicalPosition::new(icon_rect.left, icon_rect.top)
-                        .to_physical(scale_factor),
-                    size: crate::dpi::LogicalSize::new(
-                        icon_rect.right.saturating_sub(icon_rect.left),
-                        icon_rect.bottom.saturating_sub(icon_rect.top),
-                    )
-                    .to_physical(scale_factor),
-                },
+                icon_rect: get_tray_rect(subclass_input.internal_id, hwnd, scale_factor),
                 click_type: event,
             });
 
@@ -412,6 +366,7 @@ unsafe extern "system" fn tray_subclass_proc(
     DefSubclassProc(hwnd, msg, wparam, lparam)
 }
 
+#[inline]
 unsafe fn show_tray_menu(hwnd: HWND, menu: HMENU, x: i32, y: i32) {
     // bring the hidden window to the foreground so the pop up menu
     // would automatically hide on click outside
@@ -428,6 +383,7 @@ unsafe fn show_tray_menu(hwnd: HWND, menu: HMENU, x: i32, y: i32) {
     );
 }
 
+#[inline]
 unsafe fn register_tray_icon(
     hwnd: HWND,
     tray_id: u32,
@@ -465,6 +421,7 @@ unsafe fn register_tray_icon(
     Shell_NotifyIconW(NIM_ADD, &mut nid as _) == 1
 }
 
+#[inline]
 unsafe fn remove_tray_icon(hwnd: HWND, id: u32) {
     let mut nid = NOTIFYICONDATAW {
         uFlags: NIF_ICON,
@@ -475,5 +432,33 @@ unsafe fn remove_tray_icon(hwnd: HWND, id: u32) {
 
     if Shell_NotifyIconW(NIM_DELETE, &mut nid as _) == 0 {
         eprintln!("Error removing system tray icon");
+    }
+}
+
+#[inline]
+fn get_tray_rect(id: u32, hwnd: HWND, scale_factor: f64) -> Rect {
+    let nid = NOTIFYICONIDENTIFIER {
+        hWnd: hwnd,
+        cbSize: std::mem::size_of::<NOTIFYICONIDENTIFIER>() as _,
+        uID: id,
+        ..unsafe { std::mem::zeroed() }
+    };
+
+    let mut icon_rect = RECT {
+        left: 0,
+        bottom: 0,
+        right: 0,
+        top: 0,
+    };
+    unsafe { Shell_NotifyIconGetRect(&nid, &mut icon_rect) };
+
+    Rect {
+        position: crate::dpi::LogicalPosition::new(icon_rect.left, icon_rect.top)
+            .to_physical(scale_factor),
+        size: crate::dpi::LogicalSize::new(
+            icon_rect.right.saturating_sub(icon_rect.left),
+            icon_rect.bottom.saturating_sub(icon_rect.top),
+        )
+        .to_physical(scale_factor),
     }
 }


### PR DESCRIPTION
This PR adds a call that retrieves the tray icon frame. I am still trying to plug it into tauri to test it. Maybe some of you can do that faster. I am having hard time overriding tray-icon and tauri in my app's cargo.toml.

Fixes https://github.com/tauri-apps/tray-icon/issues/86 for macOS


Cross commit for `tauri` can be cherry picked from here [065b7697da28dcf509c1955bc4226e2b631cf83e](https://github.com/pronebird/tauri/commit/065b7697da28dcf509c1955bc4226e2b631cf83e)