### PR TITLE
fix(macos): mouse position was not scaled

### DIFF
--- a/.changes/fix-mac-mouse-position.md
+++ b/.changes/fix-mac-mouse-position.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": "patch"
+---
+
+On macOS, fix an issue where the mouse position was not scaled.

--- a/.changes/fix-mac-mouse-position.md
+++ b/.changes/fix-mac-mouse-position.md
@@ -2,4 +2,4 @@
 "tray-icon": "patch"
 ---
 
-On macOS, fix an issue where the mouse position was not scaled.
+On macOS, fix tray event position not scaled properly.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -370,13 +370,15 @@ fn make_tray_target_class() -> *const Class {
 
             // cursor position
             let mouse_location: NSPoint = msg_send![class!(NSEvent), mouseLocation];
+            let scale_factor = unsafe { NSWindow::backingScaleFactor(window) };
 
             let event = TrayIconEvent {
                 id: TrayIconId(id_str.to_string()),
-                position: crate::dpi::PhysicalPosition::new(
+                position: crate::dpi::LogicalPosition::new(
                     mouse_location.x,
                     flip_window_screen_coordinates(mouse_location.y),
-                ),
+                )
+                .to_physical(scale_factor),
                 icon_rect,
                 click_type: click_event,
             };


### PR DESCRIPTION
```
let mouse_location: NSPoint = msg_send![class!(NSEvent), mouseLocation];
```
`mouseLocation` returns logical position on my side