### PR TITLE
Rewrite to use `objc2`

### DIFF
--- a/.changes/add_mainthread_error.md
+++ b/.changes/add_mainthread_error.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": minor
+---
+
+Added a new variant `NotMainThread` to the `Error` enum, which is emitted on macOS when trying to create tray icons from a thread that is not the main thread.

--- a/.changes/rewrite_objc2.md
+++ b/.changes/rewrite_objc2.md
@@ -1,0 +1,7 @@
+---
+"tray-icon": patch
+---
+
+Rewrite the internals of the crate to use `objc2` instead of `objc`.
+
+This should have no user-facing changes, other than improved memory safety, and less leaking.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,13 @@ description = "Create tray icons for desktop applications"
 homepage = "https://github.com/tauri-apps/tray-icon"
 repository = "https://github.com/tauri-apps/tray-icon"
 license = "MIT OR Apache-2.0"
-categories = [ "gui" ]
+categories = ["gui"]
 
 [features]
-default = [ "libxdo" ]
-libxdo = [ "muda/libxdo" ]
-serde = [ "muda/serde", "dep:serde" ]
-common-controls-v6 = [ "muda/common-controls-v6" ]
+default = ["libxdo"]
+libxdo = ["muda/libxdo"]
+serde = ["muda/serde", "dep:serde"]
+common-controls-v6 = ["muda/common-controls-v6"]
 
 [dependencies]
 muda = { version = "0.13", default-features = false }
@@ -28,7 +28,7 @@ features = [
   "Win32_Foundation",
   "Win32_System_SystemServices",
   "Win32_Graphics_Gdi",
-  "Win32_UI_Shell"
+  "Win32_UI_Shell",
 ]
 
 [target."cfg(target_os = \"linux\")".dependencies]
@@ -39,8 +39,31 @@ dirs = "5"
 gtk = "0.18"
 
 [target."cfg(target_os = \"macos\")".dependencies]
-cocoa = "0.25"
-objc = "0.2"
+objc2 = "0.5.2"
+objc2-foundation = { version = "0.2.2", features = [
+  "block2",
+  "NSArray",
+  "NSData",
+  "NSEnumerator",
+  "NSGeometry",
+  "NSString",
+  "NSThread",
+] }
+objc2-app-kit = { version = "0.2.2", features = [
+  "NSButton",
+  "NSCell",
+  "NSControl",
+  "NSEvent",
+  "NSImage",
+  "NSMenu",
+  "NSResponder",
+  "NSStatusBar",
+  "NSStatusBarButton",
+  "NSStatusItem",
+  "NSTrackingArea",
+  "NSView",
+  "NSWindow",
+] }
 core-graphics = "0.23"
 
 [target."cfg(target_os = \"macos\")".dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[error(transparent)]
     PngEncodingError(#[from] png::EncodingError),
+    #[error("not on the main thread")]
+    NotMainThread,
 }
 
 /// Convenient type alias of Result type for tray-icon.

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -31,7 +31,7 @@ impl RgbaIcon {
         let pixels =
             unsafe { std::slice::from_raw_parts_mut(rgba.as_ptr() as *mut Pixel, pixel_count) };
         for pixel in pixels {
-            and_mask.push(pixel.a.wrapping_sub(std::u8::MAX)); // invert alpha channel
+            and_mask.push(pixel.a.wrapping_sub(u8::MAX)); // invert alpha channel
             pixel.convert_to_bgra();
         }
         assert_eq!(and_mask.len(), pixel_count);


### PR DESCRIPTION
This ensures that memory management rules are upheld, as well as greatly improving type-safety.

API-wise, this adds a new error case `NotMainThread`, which is triggered when a TrayIcon is created on a thread that is not the main thread.

There is probably a bug lurking in here somewhere, I'm not too familiar with the exact details of the `NSStatusItem` API.
Notably, there's also still a lot of `if Some(...)` checks that I'm not sure are completely necessary, though this PR shouldn't make the situation any worse on that front.

Related: The migration to `objc2` in `wry`: https://github.com/tauri-apps/wry/issues/1239