### PR TITLE
feat: add double click events back

### DIFF
--- a/.changes/double-click.md
+++ b/.changes/double-click.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": "patch"
+---
+
+On Windows, Add and emit `DoubleClick` variant for `TrayIconEvent`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,6 +428,19 @@ pub enum TrayIconEvent {
         /// Mouse button state when this event was triggered.
         button_state: MouseButtonState,
     },
+    /// A double click happened on the tray icon. **Windows Only**
+    DoubleClick {
+        /// Id of the tray icon which triggered this event.
+        id: TrayIconId,
+        /// Physical Position of this event.
+        position: dpi::PhysicalPosition<f64>,
+        /// Position and size of the tray icon.
+        rect: Rect,
+        /// Mouse button that triggered this event.
+        button: MouseButton,
+        /// Mouse button state when this event was triggered.
+        button_state: MouseButtonState,
+    },
     /// The mouse entered the tray icon region.
     Enter {
         /// Id of the tray icon which triggered this event.
@@ -515,6 +528,7 @@ impl TrayIconEvent {
     pub fn id(&self) -> &TrayIconId {
         match self {
             TrayIconEvent::Click { id, .. } => id,
+            TrayIconEvent::DoubleClick { id, .. } => id,
             TrayIconEvent::Enter { id, .. } => id,
             TrayIconEvent::Move { id, .. } => id,
             TrayIconEvent::Leave { id, .. } => id,

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -20,10 +20,11 @@ use windows_sys::{
                 CreateWindowExW, DefWindowProcW, DestroyWindow, GetCursorPos, KillTimer,
                 RegisterClassW, RegisterWindowMessageA, SendMessageW, SetForegroundWindow,
                 SetTimer, TrackPopupMenu, CREATESTRUCTW, CW_USEDEFAULT, GWL_USERDATA, HICON, HMENU,
-                TPM_BOTTOMALIGN, TPM_LEFTALIGN, WM_CREATE, WM_DESTROY, WM_LBUTTONDOWN,
-                WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE, WM_NCCREATE,
-                WM_RBUTTONDOWN, WM_RBUTTONUP, WM_TIMER, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE,
-                WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_OVERLAPPED,
+                TPM_BOTTOMALIGN, TPM_LEFTALIGN, WM_CREATE, WM_DESTROY, WM_LBUTTONDBLCLK,
+                WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK, WM_MBUTTONDOWN, WM_MBUTTONUP,
+                WM_MOUSEMOVE, WM_NCCREATE, WM_RBUTTONDBLCLK, WM_RBUTTONDOWN, WM_RBUTTONUP,
+                WM_TIMER, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
+                WS_EX_TRANSPARENT, WS_OVERLAPPED,
             },
         },
     },
@@ -332,6 +333,9 @@ unsafe extern "system" fn tray_proc(
                     | WM_LBUTTONUP
                     | WM_RBUTTONUP
                     | WM_MBUTTONUP
+                    | WM_LBUTTONDBLCLK
+                    | WM_RBUTTONDBLCLK
+                    | WM_MBUTTONDBLCLK
                     | WM_MOUSEMOVE
             ) =>
         {
@@ -391,7 +395,27 @@ unsafe extern "system" fn tray_proc(
                     button: MouseButton::Middle,
                     button_state: MouseButtonState::Up,
                 },
-
+                WM_LBUTTONDBLCLK => TrayIconEvent::DoubleClick {
+                    id,
+                    rect,
+                    position,
+                    button: MouseButton::Left,
+                    button_state: MouseButtonState::Up,
+                },
+                WM_RBUTTONDBLCLK => TrayIconEvent::DoubleClick {
+                    id,
+                    rect,
+                    position,
+                    button: MouseButton::Right,
+                    button_state: MouseButtonState::Up,
+                },
+                WM_MBUTTONDBLCLK => TrayIconEvent::DoubleClick {
+                    id,
+                    rect,
+                    position,
+                    button: MouseButton::Middle,
+                    button_state: MouseButtonState::Up,
+                },
                 WM_MOUSEMOVE if !userdata.entered => {
                     userdata.entered = true;
                     TrayIconEvent::Enter { id, rect, position }


### PR DESCRIPTION
This was previously removed in #161 in tray-icon@v0.14

closes #173