### PR TITLE
feat: add set_icon_with_as_template

### DIFF
--- a/.changes/add-macos-set_icon_with_as_template.md
+++ b/.changes/add-macos-set_icon_with_as_template.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+Add `set_icon_with_as_template` method to update icon and `is_template` property, preventing glitchy effects during icon animation on macOS.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,6 +387,19 @@ impl TrayIcon {
         let _ = is_template;
     }
 
+    pub fn set_icon_with_as_template(&self, icon: Option<Icon>, is_template: bool) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        return self
+            .tray
+            .borrow_mut()
+            .set_icon_with_as_template(icon, is_template);
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = is_template;
+            Ok(())
+        }
+    }
+
     /// Disable or enable showing the tray menu on left click.
     ///
     /// ## Platform-specific:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,6 +395,7 @@ impl TrayIcon {
             .set_icon_with_as_template(icon, is_template);
         #[cfg(not(target_os = "macos"))]
         {
+            let _ = icon;
             let _ = is_template;
             Ok(())
         }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -114,12 +114,7 @@ impl TrayIcon {
     pub fn set_icon(&mut self, icon: Option<Icon>) -> crate::Result<()> {
         if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
         {
-            set_icon_for_ns_status_item_button(
-                ns_status_item,
-                icon.clone(),
-                self.attrs.icon_is_template,
-                self.mtm,
-            )?;
+            set_icon_for_ns_status_item_button(ns_status_item, icon.clone(), false, self.mtm)?;
             tray_target.update_dimensions();
         }
         self.attrs.icon = icon;
@@ -219,6 +214,25 @@ impl TrayIcon {
             }
         }
         self.attrs.icon_is_template = is_template;
+    }
+
+    pub fn set_icon_with_as_template(
+        &mut self,
+        icon: Option<Icon>,
+        is_template: bool,
+    ) -> crate::Result<()> {
+        if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
+        {
+            set_icon_for_ns_status_item_button(
+                ns_status_item,
+                icon.clone(),
+                is_template,
+                self.mtm,
+            )?;
+            tray_target.update_dimensions();
+        }
+        self.attrs.icon = icon;
+        Ok(())
     }
 
     pub fn set_show_menu_on_left_click(&mut self, enable: bool) {

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -232,6 +232,7 @@ impl TrayIcon {
             tray_target.update_dimensions();
         }
         self.attrs.icon = icon;
+        self.attrs.icon_is_template = is_template;
         Ok(())
     }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -114,7 +114,12 @@ impl TrayIcon {
     pub fn set_icon(&mut self, icon: Option<Icon>) -> crate::Result<()> {
         if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
         {
-            set_icon_for_ns_status_item_button(ns_status_item, icon.clone(), false, self.mtm)?;
+            set_icon_for_ns_status_item_button(
+                ns_status_item,
+                icon.clone(),
+                self.attrs.icon_is_template,
+                self.mtm,
+            )?;
             tray_target.update_dimensions();
         }
         self.attrs.icon = icon;


### PR DESCRIPTION
Closes https://github.com/tauri-apps/tray-icon/issues/203

I am not sure this is correct in 100% cases but it feels more natural that when you change the icon you want the similar settings for its `icon_is_template` value. 