### PR TITLE
feat: expose method to get the underlying window handle on Windows

### DIFF
--- a/.changes/expose_window_handle.md
+++ b/.changes/expose_window_handle.md
@@ -1,0 +1,5 @@
+---
+tray-icon: patch
+---
+
+Add `window_handle` method to retrieve the underlying `hwnd` on Windows

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,6 +460,16 @@ impl TrayIcon {
     pub fn rect(&self) -> Option<Rect> {
         self.tray.borrow().rect()
     }
+
+    /// Get the tray icon's underlying [window handle](windows_sys::Win32::Foundation::HWND).
+    ///
+    /// ## Platform-specific:
+    ///
+    /// **Windows only.**
+    #[cfg(windows)]
+    pub fn window_handle(&self) -> windows_sys::Win32::Foundation::HWND {
+        self.tray.borrow().hwnd()
+    }
 }
 
 /// Describes a tray icon event.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,11 +461,9 @@ impl TrayIcon {
         self.tray.borrow().rect()
     }
 
-    /// Get the tray icon's underlying [window handle](windows_sys::Win32::Foundation::HWND).
+    /// Get the tray icon's underlying [window handle](windows_sys::Win32::Foundation::HWND) **Windows only**.
     ///
-    /// ## Platform-specific:
-    ///
-    /// **Windows only.**
+    /// This window handle is valid as long as the tray icon.
     #[cfg(windows)]
     pub fn window_handle(&self) -> windows_sys::Win32::Foundation::HWND {
         self.tray.borrow().hwnd()

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -257,6 +257,10 @@ impl TrayIcon {
     pub fn rect(&self) -> Option<Rect> {
         get_tray_rect(self.internal_id, self.hwnd).map(Into::into)
     }
+
+    pub fn hwnd(&self) -> HWND {
+        self.hwnd
+    }
 }
 
 impl Drop for TrayIcon {


### PR DESCRIPTION
This PR exposes a method to access the window handle on Windows only.

I'm creating a tray icon that needs to interact with [the system's media controls](https://github.com/Sinono3/souvlaki) and Windows requires a reference to the underlying `hwnd` for this to work. Considering Mac and Linux don't use the standard window handle types for tray icons, I don't think it's possible to expose this in a cross-platform way.