### PR TITLE
fix: fix clippy format error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub struct TrayIconAttributes {
     /// ## Platform-specific:
     ///
     /// - **Linux:** Sometimes the icon won't be visible unless a menu is set.
-    ///     Setting an empty [`Menu`](crate::menu::Menu) is enough.
+    ///   Setting an empty [`Menu`](crate::menu::Menu) is enough.
     pub icon: Option<Icon>,
 
     /// Tray icon temp dir path. **Linux only**.


### PR DESCRIPTION
Fixes the failing CI. Clippy wants the next line to be aligned with the first character on the preceding line.