### PR TITLE
Uses the tray-icon ID when building the icon on linux (GTK)

### DIFF
--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -23,7 +23,8 @@ pub struct TrayIcon {
 impl TrayIcon {
     pub fn new(_id: TrayIconId, attrs: TrayIconAttributes) -> crate::Result<Self> {
         let id = COUNTER.next();
-        let mut indicator = AppIndicator::new("tray-icon tray app", "");
+        let title = format!("tray-icon tray app {}", _id.as_ref());
+        let mut indicator = AppIndicator::new(title.as_str(), "");
         indicator.set_status(AppIndicatorStatus::Active);
 
         let (parent_path, icon_path) = temp_icon_path(attrs.temp_dir_path.as_ref(), id, 0)?;


### PR DESCRIPTION
See some background info here: https://github.com/tauri-apps/tray-icon/issues/264.

I'm just appending the tray-icon ID to the hard-coded tray title when instantiating AppIndicator.