### PR TITLE
feat: expose platform objects for advanced customization

### DIFF
--- a/.changes/expose-platform-objects.md
+++ b/.changes/expose-platform-objects.md
@@ -2,4 +2,6 @@
 tray-icon: patch
 ---
 
-Expose platform objects for advanced customization
+Add platform specific methods to access the underlying native handles of the tray (similar to `TrayIcon::window_handle`):
+- `TrayIcon::ns_status_item` for macOS
+- `TrayIcon::app_indicator` for Linux.

--- a/.changes/expose-platform-objects.md
+++ b/.changes/expose-platform-objects.md
@@ -1,0 +1,5 @@
+---
+tray-icon: patch
+---
+
+Expose platform objects for advanced customization

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,7 +484,7 @@ impl TrayIcon {
     /// The returned pointer is valid as long as the `TrayIcon` is.
     #[cfg(all(unix, not(target_os = "macos")))]
     pub unsafe fn app_indicator(&self) -> *const libappindicator::AppIndicator {
-        unsafe { self.tray.borrow().app_indicator() as *const _ }
+        self.tray.borrow().app_indicator() as *const _
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,9 +469,18 @@ impl TrayIcon {
         self.tray.borrow().hwnd()
     }
 
+    /// Get the tray icon's underlying [NSStatusItem](objc2_app_kit::NSStatusItem) **macOS only**.
+    ///
+    /// Returns `None` if the status item is not available.
     #[cfg(target_os = "macos")]
     pub fn ns_status_item(&self) -> Option<objc2::rc::Retained<objc2_app_kit::NSStatusItem>> {
         self.tray.borrow().ns_status_item().cloned()
+    }
+
+    /// Get the tray icon's underlying [AppIndicator](libappindicator::AppIndicator) **Linux only**.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    pub fn app_indicator(&self) -> libappindicator::AppIndicator {
+        self.tray.borrow().app_indicator().clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,9 +478,13 @@ impl TrayIcon {
     }
 
     /// Get the tray icon's underlying [AppIndicator](libappindicator::AppIndicator) **Linux only**.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is valid as long as the `TrayIcon` is.
     #[cfg(all(unix, not(target_os = "macos")))]
-    pub fn app_indicator(&self) -> &libappindicator::AppIndicator {
-        unsafe { &*(self.tray.borrow().app_indicator() as *const _) }
+    unsafe pub fn app_indicator(&self) -> *const libappindicator::AppIndicator {
+        unsafe { self.tray.borrow().app_indicator() as *const _ }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,7 +483,7 @@ impl TrayIcon {
     ///
     /// The returned pointer is valid as long as the `TrayIcon` is.
     #[cfg(all(unix, not(target_os = "macos")))]
-    unsafe pub fn app_indicator(&self) -> *const libappindicator::AppIndicator {
+    pub unsafe fn app_indicator(&self) -> *const libappindicator::AppIndicator {
         unsafe { self.tray.borrow().app_indicator() as *const _ }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,8 +479,8 @@ impl TrayIcon {
 
     /// Get the tray icon's underlying [AppIndicator](libappindicator::AppIndicator) **Linux only**.
     #[cfg(all(unix, not(target_os = "macos")))]
-    pub fn app_indicator(&self) -> libappindicator::AppIndicator {
-        self.tray.borrow().app_indicator().clone()
+    pub fn app_indicator(&self) -> &libappindicator::AppIndicator {
+        unsafe { &*(self.tray.borrow().app_indicator() as *const _) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,6 +468,11 @@ impl TrayIcon {
     pub fn window_handle(&self) -> windows_sys::Win32::Foundation::HWND {
         self.tray.borrow().hwnd()
     }
+
+    #[cfg(target_os = "macos")]
+    pub fn ns_status_item(&self) -> Option<objc2::rc::Retained<objc2_app_kit::NSStatusItem>> {
+        self.tray.borrow().ns_status_item().cloned()
+    }
 }
 
 /// Describes a tray icon event.

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -106,6 +106,10 @@ impl TrayIcon {
     pub fn rect(&self) -> Option<crate::Rect> {
         None
     }
+
+    pub fn app_indicator(&self) -> &AppIndicator {
+        &self.indicator
+    }
 }
 
 impl Drop for TrayIcon {

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -251,6 +251,10 @@ impl TrayIcon {
             window.map(|window| get_tray_rect(&window))
         }
     }
+
+    pub fn ns_status_item(&self) -> Option<&Retained<NSStatusItem>> {
+        self.ns_status_item.as_ref()
+    }
 }
 
 impl Drop for TrayIcon {


### PR DESCRIPTION
This PR adds public API methods to expose the underlying platform-specific objects used by tray icons, enabling advanced customization and integration with platform-native features.

## Changes

- macOS: Added ns_status_item() method to access the underlying NSStatusItem
- Linux: Added app_indicator() method to access the underlying AppIndicator
- Windows: HWND access was already available via existing hwnd() method

## Motivation

Users often need access to platform-specific objects to:
- Implement advanced customization not covered by the cross-platform API
- Integrate with other platform-native libraries
- Access platform-specific features and behaviors
- Perform low-level operations on the tray icon

## API

### macOS

```rust
#[cfg(target_os = "macos")]
pub fn ns_status_item(&self) -> Option<objc2::rc::Retained<objc2_app_kit::NSStatusItem>>
```

Returns the underlying NSStatusItem if available, allowing direct interaction with macOS-specific status bar features.

### Linux

```rust
#[cfg(all(unix, not(target_os = "macos")))]
pub fn app_indicator(&self) -> &libappindicator::AppIndicator
```

Returns a reference to the underlying AppIndicator, enabling access to libappindicator-specific functionality.

