### PR TITLE
Exclude example files from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/tauri-apps/tray-icon"
 license = "MIT OR Apache-2.0"
 categories = ["gui"]
 rust-version = "1.71"
-include = ["README.md", "src/**/*.rs", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT"]
+include = ["README.md", "src/**/*.rs", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT", "LICENSE.spdx"]
 
 [features]
 default = ["libxdo"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/tauri-apps/tray-icon"
 license = "MIT OR Apache-2.0"
 categories = ["gui"]
 rust-version = "1.71"
+include = ["README.md", "src/**/*.rs", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [features]
 default = ["libxdo"]


### PR DESCRIPTION
During our dependency reviews we discovered that the muda crate as uploaded to crates.io includes example data (a png) that are not used by the rust code. This increases the package size and makes it harder to review the source code as it now includes binary data.

This commit explicitly includes only relevant files. This helps to reduce the package size

Before: 35 files, 272.6KiB (70.5KiB compressed)
After: 20 files, 230.7KiB (56.9KiB compressed)

Overall based on the reduction in the compressed package size and the current download numbers that results to a traffic reduction for crates.io of around 8GB / Month.