### PR TITLE
Destroy a window if tray creation fails on Windows. Fixes #276

### DIFF
--- a/.changes/destroy-window-fix.md
+++ b/.changes/destroy-window-fix.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+Fix a problem on Windows platform where the created window was not destroyed correctly in case the tray icon creation fails.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -127,7 +127,9 @@ impl TrayIcon {
             let hicon = attrs.icon.as_ref().map(|i| i.inner.as_raw_handle());
 
             if !register_tray_icon(hwnd, internal_id, &hicon, &attrs.tooltip) {
-                return Err(crate::Error::OsError(std::io::Error::last_os_error()));
+                let result = Err(crate::Error::OsError(std::io::Error::last_os_error()));
+                DestroyWindow(hwnd);
+                return result;
             }
 
             if let Some(menu) = &attrs.menu {


### PR DESCRIPTION
This PR fixes a problem with the remaining window and the window message handler if the tray creation fails on Windows. May happen if the application is auto-started too quickly before the explorer.exe initializes taskbar correctly.