### PR TITLE
Fix infinite loop in BadIcon error source

### DIFF
--- a/.changes/bad-icon-source.md
+++ b/.changes/bad-icon-source.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+Fix infinite loops when printing the full error chain (for example "{err:?}" with anyhow) for `BadIcon`

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -59,7 +59,10 @@ impl fmt::Display for BadIcon {
 
 impl Error for BadIcon {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(self)
+        match self {
+            BadIcon::OsError(e) => Some(e),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
Error impl for BadIcon returns the error itself as the cause:

```rust
impl Error for BadIcon {
    fn source(&self) -> Option<&(dyn Error + 'static)> {
        Some(self)
    }
}
```

This causes infinite log loops when printing the full error chain (for example "{err:?}" with anyhow)

The fix is to match on the error type and return appropriately.