### PR TITLE
Revert "fix(windows): prevent visible tray menu freeze on device change events (#268)"

### DIFF
--- a/.changes/revert-268.md
+++ b/.changes/revert-268.md
@@ -1,0 +1,5 @@
+---
+tray-icon: patch
+---
+
+This hotfix reverts https://github.com/tauri-apps/tray-icon/pull/268 because it caused `assertion failed: flush_paint_messages` panics.

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -124,7 +124,7 @@ fn main() {
     });
 
     if let Err(err) = event_loop.run_app(&mut app) {
-        println!("Error: {err:?}");
+        println!("Error: {:?}", err);
     }
 }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -17,11 +17,10 @@ use windows_sys::{
                 NIM_ADD, NIM_DELETE, NIM_MODIFY, NOTIFYICONDATAW, NOTIFYICONIDENTIFIER,
             },
             WindowsAndMessaging::{
-                CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetCursorPos,
-                KillTimer, PeekMessageW, RegisterClassW, RegisterWindowMessageA, SendMessageW,
-                SetForegroundWindow, SetTimer, TrackPopupMenu, TranslateMessage, CREATESTRUCTW,
-                CW_USEDEFAULT, GWL_USERDATA, HICON, HMENU, PM_REMOVE, TPM_BOTTOMALIGN,
-                TPM_LEFTALIGN, WM_CREATE, WM_DESTROY, WM_DEVICECHANGE, WM_LBUTTONDBLCLK,
+                CreateWindowExW, DefWindowProcW, DestroyWindow, GetCursorPos, KillTimer,
+                RegisterClassW, RegisterWindowMessageA, SendMessageW, SetForegroundWindow,
+                SetTimer, TrackPopupMenu, CREATESTRUCTW, CW_USEDEFAULT, GWL_USERDATA, HICON, HMENU,
+                TPM_BOTTOMALIGN, TPM_LEFTALIGN, WM_CREATE, WM_DESTROY, WM_LBUTTONDBLCLK,
                 WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDBLCLK, WM_MBUTTONDOWN, WM_MBUTTONUP,
                 WM_MOUSEMOVE, WM_NCCREATE, WM_RBUTTONDBLCLK, WM_RBUTTONDOWN, WM_RBUTTONUP,
                 WM_TIMER, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
@@ -307,20 +306,6 @@ unsafe extern "system" fn tray_proc(
     let userdata = &mut *(userdata_ptr);
 
     match msg {
-        WM_DEVICECHANGE => {
-            userdata.entered = false;
-            userdata.last_position = None;
-
-            KillTimer(hwnd, WM_USER_LEAVE_TIMER_ID as _);
-
-            let mut msg = std::mem::zeroed();
-            while PeekMessageW(&mut msg, std::ptr::null_mut(), 0, 0, PM_REMOVE) != 0 {
-                TranslateMessage(&msg);
-                DispatchMessageW(&msg);
-            }
-
-            return 1;
-        }
         WM_DESTROY => {
             drop(Box::from_raw(userdata_ptr));
             return 0;


### PR DESCRIPTION
This reverts commit 2a6a19bbac9848d3887b12599b2860ba6653c8f7 / PR #268 as it seems to be the current main (but not only) cause for https://github.com/tauri-apps/tao/issues/1140 / https://github.com/tauri-apps/tauri/issues/14088