### PR TITLE
feat: allow disabling menu on right click and add `show_menu()`

### DIFF
--- a/.changes/show-menu-and-menu-on-right-click.md
+++ b/.changes/show-menu-and-menu-on-right-click.md
@@ -1,0 +1,7 @@
+---
+"tray-icon": minor
+---
+
+Added `with_menu_on_right_click` builder method, `set_show_menu_on_right_click` to control whether the context menu is shown on right click (analogous to the existing left click option), and `show_menu()` to programmatically display the tray menu. 
+
+Together these enable dynamic menu workflows where the menu content is updated before being shown, for example by disabling automatic right-click menu, listening for the click event, updating items, and then calling `show_menu()`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,13 @@ pub struct TrayIconAttributes {
     /// - **Linux:** Unsupported.
     pub menu_on_left_click: bool,
 
+    /// Whether to show the tray menu on right click or not, default is `true`.
+    ///
+    /// ## Platform-specific:
+    ///
+    /// - **Linux:** Unsupported.
+    pub menu_on_right_click: bool,
+
     /// Tray icon title.
     ///
     /// ## Platform-specific
@@ -207,6 +214,7 @@ impl Default for TrayIconAttributes {
             temp_dir_path: None,
             icon_is_template: false,
             menu_on_left_click: true,
+            menu_on_right_click: true,
             title: None,
         }
     }
@@ -304,6 +312,16 @@ impl TrayIconBuilder {
     /// - **Linux:** Unsupported.
     pub fn with_menu_on_left_click(mut self, enable: bool) -> Self {
         self.attrs.menu_on_left_click = enable;
+        self
+    }
+
+    /// Whether to show the tray menu on right click or not, default is `true`.
+    ///
+    /// ## Platform-specific:
+    ///
+    /// - **Linux:** Unsupported.
+    pub fn with_menu_on_right_click(mut self, enable: bool) -> Self {
+        self.attrs.menu_on_right_click = enable;
         self
     }
 
@@ -460,6 +478,18 @@ impl TrayIcon {
     pub fn set_show_menu_on_left_click(&self, enable: bool) {
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         self.tray.borrow_mut().set_show_menu_on_left_click(enable);
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        let _ = enable;
+    }
+
+    /// Disable or enable showing the tray menu on right click.
+    ///
+    /// ## Platform-specific:
+    ///
+    /// - **Linux:** Unsupported.
+    pub fn set_show_menu_on_right_click(&self, enable: bool) {
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        self.tray.borrow_mut().set_show_menu_on_right_click(enable);
         #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         let _ = enable;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,6 +494,19 @@ impl TrayIcon {
         let _ = enable;
     }
 
+    /// Manually show the tray menu at the current cursor position.
+    ///
+    /// This is useful when you want to control when the menu is displayed,
+    /// for example after updating menu items dynamically.
+    ///
+    /// ## Platform-specific:
+    ///
+    /// - **Linux:** Unsupported.
+    pub fn show_menu(&self) {
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        self.tray.borrow().show_menu();
+    }
+
     /// Get tray icon rect.
     ///
     /// ## Platform-specific:

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -86,6 +86,7 @@ impl TrayIcon {
                 ),
                 status_item: ns_status_item.retain(),
                 menu_on_left_click: Cell::new(attrs.menu_on_left_click),
+                menu_on_right_click: Cell::new(attrs.menu_on_right_click),
             });
             let tray_target: Retained<TrayTarget> = msg_send![super(target), initWithFrame: frame];
             tray_target.setWantsLayer(true);
@@ -243,6 +244,13 @@ impl TrayIcon {
         self.attrs.menu_on_left_click = enable;
     }
 
+    pub fn set_show_menu_on_right_click(&mut self, enable: bool) {
+        if let Some(tray_target) = &self.tray_target {
+            tray_target.ivars().menu_on_right_click.set(enable);
+        }
+        self.attrs.menu_on_right_click = enable;
+    }
+
     pub fn rect(&self) -> Option<Rect> {
         let ns_status_item = self.ns_status_item.as_deref()?;
         unsafe {
@@ -305,6 +313,7 @@ struct TrayTargetIvars {
     menu: RefCell<Option<Retained<NSMenu>>>,
     status_item: Retained<NSStatusItem>,
     menu_on_left_click: Cell<bool>,
+    menu_on_right_click: Cell<bool>,
 }
 
 define_class!(
@@ -474,7 +483,10 @@ fn on_tray_click(this: &TrayTarget, button: MouseButton) {
         let ns_button = this.ivars().status_item.button(mtm).unwrap();
 
         let menu_on_left_click = this.ivars().menu_on_left_click.get();
-        if button == MouseButton::Right || (menu_on_left_click && button == MouseButton::Left) {
+        let menu_on_right_click = this.ivars().menu_on_right_click.get();
+        if (menu_on_right_click && button == MouseButton::Right)
+            || (menu_on_left_click && button == MouseButton::Left)
+        {
             let has_items = if let Some(menu) = &*this.ivars().menu.borrow() {
                 menu.numberOfItems() > 0
             } else {

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -251,6 +251,15 @@ impl TrayIcon {
         self.attrs.menu_on_right_click = enable;
     }
 
+    pub fn show_menu(&self) {
+        if let Some(ns_status_item) = &self.ns_status_item {
+            unsafe {
+                let button = ns_status_item.button(self.mtm).unwrap();
+                button.performClick(None);
+            }
+        }
+    }
+
     pub fn rect(&self) -> Option<Rect> {
         let ns_status_item = self.ns_status_item.as_deref()?;
         unsafe {

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -45,6 +45,7 @@ const WM_USER_HIDE_TRAYICON: u32 = 6006;
 const WM_USER_UPDATE_TRAYTOOLTIP: u32 = 6007;
 const WM_USER_LEAVE_TIMER_ID: u32 = 6008;
 const WM_USER_SHOW_MENU_ON_LEFT_CLICK: u32 = 6009;
+const WM_USER_SHOW_MENU_ON_RIGHT_CLICK: u32 = 6010;
 /// When the taskbar is created, it registers a message with the "TaskbarCreated" string and then broadcasts this message to all top-level windows
 /// When the application receives this message, it should assume that any taskbar icons it added have been removed and add them again.
 static S_U_TASKBAR_RESTART: Lazy<u32> =
@@ -60,6 +61,7 @@ struct TrayUserData {
     entered: bool,
     last_position: Option<PhysicalPosition<f64>>,
     menu_on_left_click: bool,
+    menu_on_right_click: bool,
 }
 
 pub struct TrayIcon {
@@ -95,6 +97,7 @@ impl TrayIcon {
                 entered: false,
                 last_position: None,
                 menu_on_left_click: attrs.menu_on_left_click,
+                menu_on_right_click: attrs.menu_on_right_click,
             };
 
             let hwnd = CreateWindowExW(
@@ -239,6 +242,17 @@ impl TrayIcon {
         }
     }
 
+    pub fn set_show_menu_on_right_click(&mut self, enable: bool) {
+        unsafe {
+            SendMessageW(
+                self.hwnd,
+                WM_USER_SHOW_MENU_ON_RIGHT_CLICK,
+                enable as usize,
+                0,
+            );
+        }
+    }
+
     pub fn set_title<S: AsRef<str>>(&mut self, _title: Option<S>) {}
 
     pub fn set_visible(&mut self, visible: bool) -> crate::Result<()> {
@@ -345,6 +359,9 @@ unsafe extern "system" fn tray_proc(
         }
         WM_USER_SHOW_MENU_ON_LEFT_CLICK => {
             userdata.menu_on_left_click = wparam != 0;
+        }
+        WM_USER_SHOW_MENU_ON_RIGHT_CLICK => {
+            userdata.menu_on_right_click = wparam != 0;
         }
 
         WM_USER_TRAYICON
@@ -459,7 +476,7 @@ unsafe extern "system" fn tray_proc(
 
             TrayIconEvent::send(event);
 
-            if lparam as u32 == WM_RBUTTONDOWN
+            if (userdata.menu_on_right_click && lparam as u32 == WM_RBUTTONDOWN)
                 || (userdata.menu_on_left_click && lparam as u32 == WM_LBUTTONDOWN)
             {
                 if let Some(menu) = userdata.hpopupmenu {

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -253,6 +253,16 @@ impl TrayIcon {
         }
     }
 
+    pub fn show_menu(&self) {
+        if let Some(menu) = &self.menu {
+            unsafe {
+                if let Some(rect) = get_tray_rect(self.internal_id, self.hwnd) {
+                    show_tray_menu(self.hwnd, menu.hpopupmenu() as _, rect.left, rect.top);
+                }
+            }
+        }
+    }
+
     pub fn set_title<S: AsRef<str>>(&mut self, _title: Option<S>) {}
 
     pub fn set_visible(&mut self, visible: bool) -> crate::Result<()> {


### PR DESCRIPTION
This PR adds two features to this crate:

1. Allows disabling showing the menu on right click (similar to how it can be done for left click)
2. Adds a method for displaying the menu manually

Which, together, fixes #254: users can disable menu on right click, update the menu on a right click event, and then display the menu once done.

PS: Claude Sonnet 4.5 has been used to generate these changes, but the code has been reviewed and changed for consistency.

### Demo

Windows:

https://github.com/user-attachments/assets/0ffbe023-e028-413e-8bf2-40d4e8dfc8f8

Mac:

https://github.com/user-attachments/assets/abfc18a3-206d-49a9-a867-1da5ab6e64e2

<details>
<summary>Code for the demo</summary>

```rust
// Example demonstrating how to prevent automatic menu opening on right-click
// and manually show the menu after updating it dynamically
//
// This example shows two approaches:
// 1. Using show_menu() to immediately display the menu after updating (demonstrated here)
// 2. Using set_show_menu_on_right_click(true) to re-enable automatic opening
//
// Approach 1 is simpler and provides better UX as the menu appears instantly
// after the update without requiring another click.

use tray_icon::{
    menu::{Menu, MenuItem},
    Icon, MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent,
};
use winit::event_loop::{ControlFlow, EventLoop};

fn main() {
    let event_loop = EventLoop::builder().build().unwrap();

    let icon = load_icon();

    // Create initial menu items
    let menu = Menu::new();
    let item1 = MenuItem::new("Item 1", true, None);
    let item2 = MenuItem::new("Item 2", true, None);
    menu.append(&item1).unwrap();
    menu.append(&item2).unwrap();

    // Build tray icon with menu_on_right_click disabled
    let tray_icon = TrayIconBuilder::new()
        .with_tooltip("Dynamic Menu Example")
        .with_icon(icon)
        .with_menu(Box::new(menu.clone()))
        .with_menu_on_right_click(false) // Disable automatic menu opening on right-click
        .build()
        .unwrap();

    println!("Tray icon created with menu_on_right_click = false");
    println!("Right-click the tray icon to see dynamic menu updates!");

    let mut counter = 2;

    #[allow(deprecated)]
    let _ = event_loop.run(move |_event, elwt| {
        elwt.set_control_flow(ControlFlow::Poll);

            // Listen for tray icon events
            if let Ok(event) = TrayIconEvent::receiver().try_recv() {
                // Check if it's a right-click down event
                if matches!(
                    event,
                    TrayIconEvent::Click {
                        button: MouseButton::Right,
                        button_state: MouseButtonState::Down,
                        ..
                    }
                ) {
                    println!("Right-click detected! Updating menu...");

                    // Update menu items dynamically
                    counter += 1;
                    
                    // Update the menu item texts
                    item1.set_text(format!("Updated Item {}", counter - 1));
                    item2.set_text(format!("Updated Item {}", counter));

                    println!("Menu updated - texts changed");

                    // Now manually show the menu after updating
                    tray_icon.show_menu();
                }

            // Note: We no longer need to handle MouseButtonState::Up
            // because we're manually showing the menu immediately after updating
            }
        });
}

fn load_icon() -> Icon {
    let (icon_rgba, icon_width, icon_height) = {
        let image = image::load_from_memory(include_bytes!("../examples/icon.png"))
            .expect("Failed to open icon path")
            .into_rgba8();
        let (width, height) = image.dimensions();
        let rgba = image.into_raw();
        (rgba, width, height)
    };
    Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
}
```

</details>
