### PR TITLE
chore: update png dependency version to 0.18

### DIFF
--- a/.changes/update-png-to-0-18.md
+++ b/.changes/update-png-to-0-18.md
@@ -1,0 +1,7 @@
+---
+"tray-icon": patch
+---
+
+Update png dependency version to 0.18.
+
+This avoids duplicated dependencies in downstream crates.

--- a/.changes/update-rust-to-1-73.md
+++ b/.changes/update-rust-to-1-73.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": minor
+---
+
+Update rust version to 1.73.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libxdo-dev libayatana-appindicator3-dev
 
-      - uses: dtolnay/rust-toolchain@1.71
+      - uses: dtolnay/rust-toolchain@1.73
       - run: cargo build
 
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "num-traits",
- "png",
+ "png 0.17.16",
  "tiff",
 ]
 
@@ -2188,7 +2188,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.11",
  "windows-sys 0.60.2",
@@ -2740,6 +2740,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.8.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3533,7 +3546,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.0",
  "once_cell",
- "png",
+ "png 0.18.0",
  "serde",
  "serde_json",
  "tao",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
 ] }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"macos\"))".dependencies]
-png = "0.17"
+png = "0.18"
 
 [dev-dependencies]
 winit = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/tauri-apps/tray-icon"
 repository = "https://github.com/tauri-apps/tray-icon"
 license = "MIT OR Apache-2.0"
 categories = ["gui"]
-rust-version = "1.71"
+rust-version = "1.73"
 include = ["README.md", "src/**/*.rs", "Cargo.toml", "LICENSE-APACHE", "LICENSE-MIT", "LICENSE.spdx"]
 
 [features]


### PR DESCRIPTION
This avoids duplicated dependencies in downstream crates.