### PR TITLE
Use app title as AppIndicator name on Linux

### DIFF
--- a/.changes/use-title-as-appindicator-name.md
+++ b/.changes/use-title-as-appindicator-name.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+Use app title as `AppIndicator` name on Linux instead of the hardcoded `"tray-icon tray app"` string. This gives each app a unique indicator identity and prevents icon collisions when multiple apps use the crate.

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -22,7 +22,11 @@ pub struct TrayIcon {
 
 impl TrayIcon {
     pub fn new(id: TrayIconId, attrs: TrayIconAttributes) -> crate::Result<Self> {
-        let mut indicator = AppIndicator::new(&format!("tray-icon tray app {}", id.as_ref()), "");
+        let indicator_name = match &attrs.title {
+            Some(title) => title.clone(),
+            None => format!("tray-icon-{}", id.as_ref()),
+        };
+        let mut indicator = AppIndicator::new(&indicator_name, "");
         indicator.set_status(AppIndicatorStatus::Active);
 
         let (parent_path, icon_path) = temp_icon_path(attrs.temp_dir_path.as_ref(), &id, 0)?;


### PR DESCRIPTION
## Summary

On Linux/GTK, the `AppIndicator` name is hardcoded to `"tray-icon tray app {id}"` ([`src/platform_impl/gtk/mod.rs:25`](https://github.com/tauri-apps/tray-icon/blob/dev/src/platform_impl/gtk/mod.rs#L25)), causing all apps using this crate to share the same generic identity in the system tray.

This leads to:
- All apps showing the same generic tooltip
- Icon collisions when apps share the default temp directory (`$XDG_RUNTIME_DIR/tray-icon/`)
- Users unable to distinguish between apps in the system tray

Reported by multiple projects: [RustDesk#14165](https://github.com/rustdesk/rustdesk/discussions/14165)

## Fix

Use the `title` from `TrayIconAttributes` (if provided) as the `AppIndicator` name, falling back to `"tray-icon-{id}"` otherwise. This gives each app a unique indicator identity without requiring any API change — apps that already call `.with_title()` will automatically get a proper indicator name.

## Related

Downstream workaround submitted for RustDesk: https://github.com/rustdesk/rustdesk/pull/14530

## Test plan

- Verified existing tests pass (`cargo test`)
- Build succeeds on Linux x86_64