### PR TITLE
fix(windows): tray icon gets blurry after changing dpi

### DIFF
--- a/.changes/blurry-after-dpi-change-windows.md
+++ b/.changes/blurry-after-dpi-change-windows.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+Fix tray icon gets blurry after changing dpi on Windows

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -360,6 +360,7 @@ unsafe extern "system" fn tray_proc(
             userdata.tooltip = *tooltip;
         }
         _ if msg == *S_U_TASKBAR_RESTART => {
+            remove_tray_icon(userdata.hwnd, userdata.internal_id);
             register_tray_icon(
                 userdata.hwnd,
                 userdata.internal_id,


### PR DESCRIPTION
Regression from #293, reference: https://github.com/tauri-apps/tray-icon/pull/293#discussion_r3116276286

This is a cherry-pick of a1cd50e