### PR TITLE
feat(macos): add TrayIconAttributes::autosave_name for NSStatusItem position persistence

### DIFF
--- a/.changes/macos-autosave-name.md
+++ b/.changes/macos-autosave-name.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": minor
+---
+
+Add `TrayIconBuilder::with_autosave_name` (and corresponding `TrayIconAttributes::autosave_name` field) so callers can hand AppKit an `NSStatusItem.setAutosaveName` key on macOS. With the autosave name set, AppKit persists the user's ⌘+drag position across launches via `NSUserDefaults`. Without it, the status item resets to the default leftmost slot every launch — which on notched MacBooks (M1+ Pro/Max/14"/16") collides with the camera cutout. No-op on Linux / Windows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,22 @@ pub struct TrayIconAttributes {
     ///   on the user's panel.  This may not be shown in all visualizations.
     /// - **Windows:** Unsupported.
     pub title: Option<String>,
+
+    /// Autosave name passed to `NSStatusItem.setAutosaveName`. AppKit
+    /// uses this key to persist the user's ⌘+drag position across
+    /// app launches via NSUserDefaults. Without it, the status item
+    /// snaps back to the default leftmost slot every launch — which
+    /// on notched MacBooks (M1+ Pro/Max/14"/16") collides with the
+    /// camera cutout.
+    ///
+    /// Pick a stable, app-unique string (typically a reverse-DNS
+    /// identifier like `"com.example.app.tray"`); changing it
+    /// invalidates the saved position.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS only.** No-op on Linux / Windows.
+    pub autosave_name: Option<String>,
 }
 
 impl Default for TrayIconAttributes {
@@ -216,6 +232,7 @@ impl Default for TrayIconAttributes {
             menu_on_left_click: true,
             menu_on_right_click: true,
             title: None,
+            autosave_name: None,
         }
     }
 }
@@ -302,6 +319,24 @@ impl TrayIconBuilder {
     /// Use the icon as a [template](https://developer.apple.com/documentation/appkit/nsimage/1520017-template?language=objc). **macOS only**.
     pub fn with_icon_as_template(mut self, is_template: bool) -> Self {
         self.attrs.icon_is_template = is_template;
+        self
+    }
+
+    /// Set the autosave name handed to `NSStatusItem.setAutosaveName`.
+    /// AppKit uses this key to persist the user's ⌘+drag position
+    /// across launches via NSUserDefaults. Without it, the status
+    /// item snaps back to the default leftmost slot every launch —
+    /// which on notched MacBooks collides with the camera cutout.
+    ///
+    /// Pick a stable, app-unique string (typically a reverse-DNS
+    /// identifier like `"com.example.app.tray"`); changing it
+    /// invalidates the saved position.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS only.** No-op on Linux / Windows.
+    pub fn with_autosave_name<S: AsRef<str>>(mut self, name: S) -> Self {
+        self.attrs.autosave_name = Some(name.as_ref().to_string());
         self
     }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -55,6 +55,18 @@ impl TrayIcon {
             NSStatusBar::systemStatusBar().statusItemWithLength(NSVariableStatusItemLength)
         };
 
+        // When the caller supplied an autosave name, hand it to
+        // AppKit so the user's ⌘+drag position survives app
+        // launches via NSUserDefaults. Without this, every launch
+        // the status item resets to the default leftmost slot,
+        // which on notched MacBooks (M1+ Pro/Max/14"/16") collides
+        // with the camera cutout.
+        if let Some(name) = attrs.autosave_name.as_deref() {
+            unsafe {
+                ns_status_item.setAutosaveName(Some(&NSString::from_str(name)));
+            }
+        }
+
         set_icon_for_ns_status_item_button(
             &ns_status_item,
             attrs.icon.clone(),


### PR DESCRIPTION
## Problem

The macOS impl creates the `NSStatusItem` without calling `setAutosaveName`. AppKit therefore can't persist the user's ⌘+drag position across launches via `NSUserDefaults`, so the status item resets to the default leftmost slot every launch.

On **notched MacBooks** (M1+ Pro/Max, 14"/16") that default slot is directly under the camera cutout — the icon is partially or fully obscured, and there's no permanent fix the user can apply.

## Solution

Add an opt-in `autosave_name: Option<String>` to `TrayIconAttributes` plus a `with_autosave_name` builder method. When set, the macOS impl forwards it to `NSStatusItem.setAutosaveName`. AppKit then handles position persistence automatically:

```rust
let tray = TrayIconBuilder::new()
    .with_autosave_name("com.example.app.tray")
    .with_icon(icon)
    .build()?;
```

The key should be a stable, app-unique string (typically reverse-DNS); changing it invalidates the saved position. No-op on Linux / Windows.

## Why opt-in (not always-on)

Default-on would require synthesizing an autosave key from `TrayIconId`, but `TrayIconId` defaults to a counter-generated string (`COUNTER.next().to_string()`) which **isn't stable across launches** — using that as the autosave key would actively break position persistence in apps that don't override the id. Opt-in keeps existing behaviour unchanged and lets callers supply a stable key intentionally.

## Verification

- `cargo check` ✓
- `cargo check --all-features` ✓
- `cargo clippy --all-targets` ✓ (no new warnings)
- `cargo test --no-run` ✓
- Real app verification: built downstream against this patched copy, ⌘+drag persists across `launchctl kickstart` restarts on a 16" M2 Max MacBook Pro.

## Changefile

Included `.changes/macos-autosave-name.md` (minor bump — additive API).

## Reference

- Apple docs: [`NSStatusItem.autosaveName`](https://developer.apple.com/documentation/appkit/nsstatusitem/autosavename)
- Same approach used by Bartender, Hidden Bar, etc.