### PR TITLE
fix(windows): preserve tray icon visibility on Explorer restart

### DIFF
--- a/.changes/fix-tray-icon-visibility-explorer-restart.md
+++ b/.changes/fix-tray-icon-visibility-explorer-restart.md
@@ -1,0 +1,11 @@
+---
+"tray-icon": patch
+---
+
+fix(windows): preserve tray icon visibility on Explorer restart
+
+Track visibility state in TrayUserData and only re-register the tray icon
+on `TaskbarCreated` if the icon was visible. Previously, a hidden tray
+icon would incorrectly reappear when Windows Explorer restarted.
+
+Also fixes error on close when `TrayIcon` is not visible.

--- a/.changes/fix-tray-icon-visibility-explorer-restart.md
+++ b/.changes/fix-tray-icon-visibility-explorer-restart.md
@@ -2,10 +2,4 @@
 "tray-icon": patch
 ---
 
-fix(windows): preserve tray icon visibility on Explorer restart
-
-Track visibility state in TrayUserData and only re-register the tray icon
-on `TaskbarCreated` if the icon was visible. Previously, a hidden tray
-icon would incorrectly reappear when Windows Explorer restarted.
-
-Also fixes error on close when `TrayIcon` is not visible.
+On Windows, preserve tray icon visibility on Explorer restart so a hidden tray icon won't become visible.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -63,6 +63,7 @@ struct TrayUserData {
     last_position: Option<PhysicalPosition<f64>>,
     menu_on_left_click: bool,
     menu_on_right_click: bool,
+    visible: bool,
 }
 
 pub struct TrayIcon {
@@ -99,6 +100,7 @@ impl TrayIcon {
                 last_position: None,
                 menu_on_left_click: attrs.menu_on_left_click,
                 menu_on_right_click: attrs.menu_on_right_click,
+                visible: true,
             };
 
             let hwnd = CreateWindowExW(
@@ -346,6 +348,7 @@ unsafe extern "system" fn tray_proc(
             userdata.icon = *icon;
         }
         WM_USER_SHOW_TRAYICON => {
+            userdata.visible = true;
             register_tray_icon(
                 userdata.hwnd,
                 userdata.internal_id,
@@ -354,6 +357,7 @@ unsafe extern "system" fn tray_proc(
             );
         }
         WM_USER_HIDE_TRAYICON => {
+            userdata.visible = false;
             remove_tray_icon(userdata.hwnd, userdata.internal_id);
         }
         WM_USER_UPDATE_TRAYTOOLTIP => {
@@ -362,12 +366,14 @@ unsafe extern "system" fn tray_proc(
         }
         _ if msg == *S_U_TASKBAR_RESTART => {
             remove_tray_icon(userdata.hwnd, userdata.internal_id);
-            register_tray_icon(
-                userdata.hwnd,
-                userdata.internal_id,
-                &userdata.icon.as_ref().map(|i| i.inner.as_raw_handle()),
-                &userdata.tooltip,
-            );
+            if userdata.visible {
+                register_tray_icon(
+                    userdata.hwnd,
+                    userdata.internal_id,
+                    &userdata.icon.as_ref().map(|i| i.inner.as_raw_handle()),
+                    &userdata.tooltip,
+                );
+            }
         }
         WM_USER_SHOW_MENU_ON_LEFT_CLICK => {
             userdata.menu_on_left_click = wparam != 0;


### PR DESCRIPTION
When Windows Explorer restarts (e.g. after system restart or crash), the TaskbarCreated message causes all tray icons to re-register. Previously this was unconditional, so a hidden tray icon would reappear.

Track visibility state in TrayUserData and only re-register on TaskbarCreated if the icon was visible.

Also fixes #289 (error on close when TrayIcon is not visible).