### PR TITLE
perf(macOS): avoid unnecessary cloing when applying tray icons, tittles, and tooltips

### DIFF
--- a/.changes/perf-macos-avoid-allocating.md
+++ b/.changes/perf-macos-avoid-allocating.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+Avoid unnecessary cloning when applying tray icons, titles, and tooltips on macOS.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -57,7 +57,7 @@ impl TrayIcon {
 
         set_icon_for_ns_status_item_button(
             &ns_status_item,
-            attrs.icon.clone(),
+            attrs.icon.as_ref(),
             attrs.icon_is_template,
             mtm,
         )?;
@@ -68,8 +68,8 @@ impl TrayIcon {
             }
         }
 
-        Self::set_tooltip_inner(&ns_status_item, attrs.tooltip.clone(), mtm)?;
-        Self::set_title_inner(&ns_status_item, attrs.title.clone(), mtm);
+        Self::set_tooltip_inner(&ns_status_item, attrs.tooltip.as_deref(), mtm)?;
+        Self::set_title_inner(&ns_status_item, attrs.title.as_deref(), mtm);
 
         let tray_target = unsafe {
             let button = ns_status_item.button(mtm).unwrap();
@@ -115,7 +115,7 @@ impl TrayIcon {
     pub fn set_icon(&mut self, icon: Option<Icon>) -> crate::Result<()> {
         if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
         {
-            set_icon_for_ns_status_item_button(ns_status_item, icon.clone(), false, self.mtm)?;
+            set_icon_for_ns_status_item_button(ns_status_item, icon.as_ref(), false, self.mtm)?;
             tray_target.update_dimensions();
         }
         self.attrs.icon = icon;
@@ -145,7 +145,7 @@ impl TrayIcon {
         let tooltip = tooltip.map(|s| s.as_ref().to_string());
         if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
         {
-            Self::set_tooltip_inner(ns_status_item, tooltip.clone(), self.mtm)?;
+            Self::set_tooltip_inner(ns_status_item, tooltip.as_deref(), self.mtm)?;
             tray_target.update_dimensions();
         }
         self.attrs.tooltip = tooltip;
@@ -170,7 +170,7 @@ impl TrayIcon {
         let title = title.map(|s| s.as_ref().to_string());
         if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
         {
-            Self::set_title_inner(ns_status_item, title.clone(), self.mtm);
+            Self::set_title_inner(ns_status_item, title.as_deref(), self.mtm);
             tray_target.update_dimensions();
         }
         self.attrs.title = title;
@@ -226,7 +226,7 @@ impl TrayIcon {
         {
             set_icon_for_ns_status_item_button(
                 ns_status_item,
-                icon.clone(),
+                icon.as_ref(),
                 is_template,
                 self.mtm,
             )?;
@@ -282,7 +282,7 @@ impl Drop for TrayIcon {
 
 fn set_icon_for_ns_status_item_button(
     ns_status_item: &NSStatusItem,
-    icon: Option<Icon>,
+    icon: Option<&Icon>,
     icon_is_template: bool,
     mtm: MainThreadMarker,
 ) -> crate::Result<()> {


### PR DESCRIPTION
Small changes.