### PR TITLE
refactor(windows): use `NIS_HIDDEN` to change visible states

### DIFF
--- a/.changes/nis-hidden.md
+++ b/.changes/nis-hidden.md
@@ -1,0 +1,5 @@
+---
+tray-icon: patch
+---
+
+Migrated to use `NIS_HIDDEN` to change visible states on Windows

--- a/.changes/set-cb-size.md
+++ b/.changes/set-cb-size.md
@@ -1,0 +1,5 @@
+---
+tray-icon: patch
+---
+
+Set `NOTIFYICONDATAW.cbSize` to `size_of::<NOTIFYICONDATAW>()`, this increased the max tooltip length from 64 to 128 characters.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -165,7 +165,7 @@ impl TrayIcon {
                 nid.hIcon = hicon;
             }
 
-            if Shell_NotifyIconW(NIM_MODIFY, &mut nid as _) == 0 {
+            if Shell_NotifyIconW(NIM_MODIFY, &nid) == 0 {
                 return Err(crate::Error::OsError(std::io::Error::last_os_error()));
             }
 
@@ -220,7 +220,7 @@ impl TrayIcon {
                 }
             }
 
-            if Shell_NotifyIconW(NIM_MODIFY, &mut nid as _) == 0 {
+            if Shell_NotifyIconW(NIM_MODIFY, &nid) == 0 {
                 return Err(crate::Error::OsError(std::io::Error::last_os_error()));
             }
 
@@ -605,7 +605,7 @@ unsafe fn register_tray_icon(
 
 #[inline]
 unsafe fn remove_tray_icon(hwnd: HWND, id: u32) {
-    let mut nid = NOTIFYICONDATAW {
+    let nid = NOTIFYICONDATAW {
         uFlags: NIF_ICON,
         hWnd: hwnd,
         uID: id,
@@ -613,7 +613,7 @@ unsafe fn remove_tray_icon(hwnd: HWND, id: u32) {
         ..std::mem::zeroed()
     };
 
-    if Shell_NotifyIconW(NIM_DELETE, &mut nid as _) == FALSE {
+    if Shell_NotifyIconW(NIM_DELETE, &nid) == FALSE {
         eprintln!("Error removing system tray icon");
     }
 }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -157,6 +157,7 @@ impl TrayIcon {
                 uFlags: NIF_ICON,
                 hWnd: self.hwnd,
                 uID: self.internal_id,
+                cbSize: size_of::<NOTIFYICONDATAW>() as u32,
                 ..std::mem::zeroed()
             };
 
@@ -208,6 +209,7 @@ impl TrayIcon {
                 uFlags: NIF_TIP,
                 hWnd: self.hwnd,
                 uID: self.internal_id,
+                cbSize: size_of::<NOTIFYICONDATAW>() as u32,
                 ..std::mem::zeroed()
             };
             if let Some(tooltip) = &tooltip {
@@ -607,6 +609,7 @@ unsafe fn remove_tray_icon(hwnd: HWND, id: u32) {
         uFlags: NIF_ICON,
         hWnd: hwnd,
         uID: id,
+        cbSize: size_of::<NOTIFYICONDATAW>() as u32,
         ..std::mem::zeroed()
     };
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -13,8 +13,9 @@ use windows_sys::{
         Foundation::{FALSE, HWND, LPARAM, LRESULT, POINT, RECT, S_OK, TRUE, WPARAM},
         UI::{
             Shell::{
-                Shell_NotifyIconGetRect, Shell_NotifyIconW, NIF_ICON, NIF_MESSAGE, NIF_TIP,
-                NIM_ADD, NIM_DELETE, NIM_MODIFY, NOTIFYICONDATAW, NOTIFYICONIDENTIFIER,
+                Shell_NotifyIconGetRect, Shell_NotifyIconW, NIF_ICON, NIF_MESSAGE, NIF_STATE,
+                NIF_TIP, NIM_ADD, NIM_DELETE, NIM_MODIFY, NIS_HIDDEN, NOTIFYICONDATAW,
+                NOTIFYICONIDENTIFIER,
             },
             WindowsAndMessaging::{
                 ChangeWindowMessageFilterEx, CreateWindowExW, DefWindowProcW, DestroyWindow,
@@ -42,11 +43,10 @@ const WM_USER_TRAYICON: u32 = 6002;
 const WM_USER_UPDATE_TRAYMENU: u32 = 6003;
 const WM_USER_UPDATE_TRAYICON: u32 = 6004;
 const WM_USER_SHOW_TRAYICON: u32 = 6005;
-const WM_USER_HIDE_TRAYICON: u32 = 6006;
-const WM_USER_UPDATE_TRAYTOOLTIP: u32 = 6007;
-const WM_USER_LEAVE_TIMER_ID: u32 = 6008;
-const WM_USER_SHOW_MENU_ON_LEFT_CLICK: u32 = 6009;
-const WM_USER_SHOW_MENU_ON_RIGHT_CLICK: u32 = 6010;
+const WM_USER_UPDATE_TRAYTOOLTIP: u32 = 6006;
+const WM_USER_LEAVE_TIMER_ID: u32 = 6007;
+const WM_USER_SHOW_MENU_ON_LEFT_CLICK: u32 = 6008;
+const WM_USER_SHOW_MENU_ON_RIGHT_CLICK: u32 = 6009;
 /// When the taskbar is created, it registers a message with the "TaskbarCreated" string and then broadcasts this message to all top-level windows
 /// When the application receives this message, it should assume that any taskbar icons it added have been removed and add them again.
 static S_U_TASKBAR_RESTART: Lazy<u32> =
@@ -64,6 +64,22 @@ struct TrayUserData {
     menu_on_left_click: bool,
     menu_on_right_click: bool,
     visible: bool,
+}
+
+impl TrayUserData {
+    fn set_tray_visible(&mut self, visible: bool) {
+        self.visible = visible;
+        let nid = NOTIFYICONDATAW {
+            uFlags: NIF_STATE,
+            hWnd: self.hwnd,
+            uID: self.internal_id,
+            dwState: if visible { 0 } else { NIS_HIDDEN },
+            dwStateMask: NIS_HIDDEN,
+            cbSize: std::mem::size_of::<NOTIFYICONDATAW>() as u32,
+            ..Default::default()
+        };
+        unsafe { Shell_NotifyIconW(NIM_MODIFY, &nid) };
+    }
 }
 
 pub struct TrayIcon {
@@ -134,7 +150,7 @@ impl TrayIcon {
 
             let hicon = attrs.icon.as_ref().map(|i| i.inner.as_raw_handle());
 
-            if !register_tray_icon(hwnd, internal_id, &hicon, &attrs.tooltip) {
+            if !register_tray_icon(hwnd, internal_id, &hicon, &attrs.tooltip, true) {
                 // Explorer/taskbar may not be ready yet (e.g., app starts before explorer.exe).
                 // Keep the window alive and wait for TaskbarCreated to re-register.
             }
@@ -272,18 +288,8 @@ impl TrayIcon {
 
     pub fn set_visible(&mut self, visible: bool) -> crate::Result<()> {
         unsafe {
-            SendMessageW(
-                self.hwnd,
-                if visible {
-                    WM_USER_SHOW_TRAYICON
-                } else {
-                    WM_USER_HIDE_TRAYICON
-                },
-                0,
-                0,
-            );
+            SendMessageW(self.hwnd, WM_USER_SHOW_TRAYICON, visible as usize, 0);
         }
-
         Ok(())
     }
 
@@ -349,33 +355,20 @@ unsafe extern "system" fn tray_proc(
             let icon = Box::from_raw(wparam as *mut Option<Icon>);
             userdata.icon = *icon;
         }
-        WM_USER_SHOW_TRAYICON => {
-            userdata.visible = true;
-            register_tray_icon(
-                userdata.hwnd,
-                userdata.internal_id,
-                &userdata.icon.as_ref().map(|i| i.inner.as_raw_handle()),
-                &userdata.tooltip,
-            );
-        }
-        WM_USER_HIDE_TRAYICON => {
-            userdata.visible = false;
-            remove_tray_icon(userdata.hwnd, userdata.internal_id);
-        }
+        WM_USER_SHOW_TRAYICON => userdata.set_tray_visible(wparam as i32 == TRUE),
         WM_USER_UPDATE_TRAYTOOLTIP => {
             let tooltip = Box::from_raw(wparam as *mut Option<String>);
             userdata.tooltip = *tooltip;
         }
         _ if msg == *S_U_TASKBAR_RESTART => {
             remove_tray_icon(userdata.hwnd, userdata.internal_id);
-            if userdata.visible {
-                register_tray_icon(
-                    userdata.hwnd,
-                    userdata.internal_id,
-                    &userdata.icon.as_ref().map(|i| i.inner.as_raw_handle()),
-                    &userdata.tooltip,
-                );
-            }
+            register_tray_icon(
+                userdata.hwnd,
+                userdata.internal_id,
+                &userdata.icon.as_ref().map(|i| i.inner.as_raw_handle()),
+                &userdata.tooltip,
+                userdata.visible,
+            );
         }
         WM_USER_SHOW_MENU_ON_LEFT_CLICK => {
             userdata.menu_on_left_click = wparam != 0;
@@ -571,6 +564,7 @@ unsafe fn register_tray_icon(
     tray_id: u32,
     hicon: &Option<HICON>,
     tooltip: &Option<String>,
+    visible: bool,
 ) -> bool {
     let mut h_icon = std::ptr::null_mut();
     let mut flags = NIF_MESSAGE;
@@ -590,6 +584,14 @@ unsafe fn register_tray_icon(
         }
     }
 
+    #[allow(non_snake_case)]
+    let dwState = if !visible {
+        flags |= NIF_STATE;
+        NIS_HIDDEN
+    } else {
+        0
+    };
+
     let mut nid = NOTIFYICONDATAW {
         uFlags: flags,
         hWnd: hwnd,
@@ -597,6 +599,9 @@ unsafe fn register_tray_icon(
         uCallbackMessage: WM_USER_TRAYICON,
         hIcon: h_icon,
         szTip: sz_tip,
+        dwState,
+        dwStateMask: dwState,
+        cbSize: std::mem::size_of::<NOTIFYICONDATAW>() as u32,
         ..std::mem::zeroed()
     };
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -4,7 +4,7 @@
 
 mod icon;
 mod util;
-use std::ptr;
+use std::{mem::size_of, ptr};
 
 use once_cell::sync::Lazy;
 use windows_sys::{
@@ -75,7 +75,7 @@ impl TrayUserData {
             uID: self.internal_id,
             dwState: if visible { 0 } else { NIS_HIDDEN },
             dwStateMask: NIS_HIDDEN,
-            cbSize: std::mem::size_of::<NOTIFYICONDATAW>() as u32,
+            cbSize: size_of::<NOTIFYICONDATAW>() as u32,
             ..Default::default()
         };
         unsafe { Shell_NotifyIconW(NIM_MODIFY, &nid) };
@@ -601,7 +601,7 @@ unsafe fn register_tray_icon(
         szTip: sz_tip,
         dwState,
         dwStateMask: dwState,
-        cbSize: std::mem::size_of::<NOTIFYICONDATAW>() as u32,
+        cbSize: size_of::<NOTIFYICONDATAW>() as u32,
         ..std::mem::zeroed()
     };
 
@@ -627,7 +627,7 @@ unsafe fn remove_tray_icon(hwnd: HWND, id: u32) {
 fn get_tray_rect(id: u32, hwnd: HWND) -> Option<RECT> {
     let nid = NOTIFYICONIDENTIFIER {
         hWnd: hwnd,
-        cbSize: std::mem::size_of::<NOTIFYICONIDENTIFIER>() as _,
+        cbSize: size_of::<NOTIFYICONIDENTIFIER>() as _,
         uID: id,
         ..unsafe { std::mem::zeroed() }
     };


### PR DESCRIPTION
So it turned out, setting the `cbSize` (729eb85) alone allows for the bigger `szTip` (#324) and also the use of `NIF_GUID` (https://github.com/tauri-apps/tray-icon/issues/324#issuecomment-4619451247)